### PR TITLE
Map: optional time extent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 
 # builds
 build
-dist
 components
 
 # misc

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "useTabs": false,
   "printWidth": 100,
   "singleQuote": true,
-  "arrowParens": "avoid",
+  "arrowParens": "always",
   "bracketSpacing": true,
   "jsxSingleQuote": false,
   "jsxBracketSameLine": false,

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -24,13 +24,15 @@ const getTracks = (state) => state.map.tracks.data
 const getTracksWithData = createSelector(
   [getTracks],
   (tracks) => {
-    const tracksWithData = tracks.filter((t) => t.data !== undefined)
+    const tracksWithData = tracks
+      .filter((t) => t.isGeoJSON !== true)
+      .filter((t) => t.data !== undefined)
     return tracksWithData
   }
 )
 
 const getTemporalExtent = (state) => state.map.module.temporalExtent
-// const getHighlightTemporalExtent = (state) => ownProps.highlightTemporalExtent
+const getHighlightTemporalExtent = (state) => state.map.module.highlightTemporalExtent
 
 const getTemporalExtentIndexes = createSelector(
   [getTemporalExtent],
@@ -50,19 +52,20 @@ const getTemporalExtentIndexes = createSelector(
   }
 )
 
-// const getHighlightTemporalExtentIndexes = createSelector(
-//   [getHighlightTemporalExtent],
-//   highlightTemporalExtent => {
-//     if (highlightTemporalExtent === undefined) {
-//       return null
-//     }
-//     const startTimestamp = highlightTemporalExtent[0].getTime()
-//     const endTimestamp = highlightTemporalExtent[1].getTime()
-//     const startIndex = convert.getOffsetedTimeAtPrecision(startTimestamp)
-//     const endIndex = convert.getOffsetedTimeAtPrecision(endTimestamp)
-//     return [startIndex, endIndex]
-//   }
-// )
+const getHighlightTemporalExtentIndexes = createSelector(
+  [getHighlightTemporalExtent],
+  (highlightTemporalExtent) => {
+    console.log(highlightTemporalExtent)
+    if (highlightTemporalExtent === undefined) {
+      return null
+    }
+    const startTimestamp = highlightTemporalExtent[0].getTime()
+    const endTimestamp = highlightTemporalExtent[1].getTime()
+    const startIndex = convert.getOffsetedTimeAtPrecision(startTimestamp)
+    const endIndex = convert.getOffsetedTimeAtPrecision(endTimestamp)
+    return [startIndex, endIndex]
+  }
+)
 
 const mapStateToProps = (state) => ({
   highlightedVessels: state.map.heatmap.highlightedVessels,
@@ -74,7 +77,7 @@ const mapStateToProps = (state) => ({
   leftWorldScaled: state.map.viewport.leftWorldScaled,
   rightWorldScaled: state.map.viewport.rightWorldScaled,
   temporalExtentIndexes: getTemporalExtentIndexes(state),
-  // highlightTemporalExtentIndexes: getHighlightTemporalExtentIndexes(state, ownProps),
+  highlightTemporalExtentIndexes: getHighlightTemporalExtentIndexes(state),
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -25,7 +25,7 @@ const getTracksWithData = createSelector(
   [getTracks],
   (tracks) => {
     const tracksWithData = tracks
-      .filter((t) => t.isGeoJSON !== true)
+      .filter((t) => t.type !== 'geojson')
       .filter((t) => t.data !== undefined)
     return tracksWithData
   }

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -37,14 +37,10 @@ const getHighlightTemporalExtent = (state) => state.map.module.highlightTemporal
 const getTemporalExtentIndexes = createSelector(
   [getTemporalExtent],
   (temporalExtent) => {
-    let finalTemporalExtent = temporalExtent
-    if (temporalExtent === undefined || temporalExtent === null) {
-      finalTemporalExtent = [new Date(1970), new Date()]
-    }
-    const startTimestamp = finalTemporalExtent[0].getTime()
+    const startTimestamp = temporalExtent[0].getTime()
     const endTimestamp = Math.max(
-      finalTemporalExtent[1].getTime(),
-      finalTemporalExtent[0].getTime() + MIN_FRAME_LENGTH_MS
+      temporalExtent[1].getTime(),
+      temporalExtent[0].getTime() + MIN_FRAME_LENGTH_MS
     )
     const startIndex = convert.getOffsetedTimeAtPrecision(startTimestamp)
     const endIndex = convert.getOffsetedTimeAtPrecision(endTimestamp)

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -51,8 +51,7 @@ const getTemporalExtentIndexes = createSelector(
 const getHighlightTemporalExtentIndexes = createSelector(
   [getHighlightTemporalExtent],
   (highlightTemporalExtent) => {
-    console.log(highlightTemporalExtent)
-    if (highlightTemporalExtent === undefined) {
+    if (highlightTemporalExtent === undefined || highlightTemporalExtent === null) {
       return null
     }
     const startTimestamp = highlightTemporalExtent[0].getTime()

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -76,8 +76,8 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  queryHeatmapVessels: (coords) => {
-    dispatch(queryHeatmapVessels(coords, ownProps.temporalExtentIndexes))
+  queryHeatmapVessels: (coords, temporalExtentIndexes) => {
+    dispatch(queryHeatmapVessels(coords, temporalExtentIndexes))
   },
   exportNativeViewport: (viewport) => {
     dispatch(exportNativeViewport(viewport))

--- a/src/map/activity/ActivityLayers.js
+++ b/src/map/activity/ActivityLayers.js
@@ -21,7 +21,7 @@ import {
 import HeatmapLayer from '../heatmap/HeatmapLayer'
 import TracksLayer from '../tracks/TracksLayer'
 
-const shouldUseRadialGradientStyle = zoom => zoom < VESSELS_RADIAL_GRADIENT_STYLE_ZOOM_THRESHOLD
+const shouldUseRadialGradientStyle = (zoom) => zoom < VESSELS_RADIAL_GRADIENT_STYLE_ZOOM_THRESHOLD
 
 // builds a texture spritesheet containing
 // - the heatmap style (radial gradient)
@@ -142,20 +142,20 @@ class ActivityLayers extends BaseControl {
     this.heatmapStage.alpha = dim === true ? VESSELS_HEATMAP_DIMMING_ALPHA : 1
   }
 
-  onTouchStart = event => {
+  onTouchStart = (event) => {
     if (!event.touches.length) {
       return
     }
-    this.queryHeatmapVessels(event.touches[0].clientX, event.touches[0].clientY)
+    this.queryCoords(event.touches[0].clientX, event.touches[0].clientY)
   }
 
-  onMouseMove = event => {
-    this.queryHeatmapVessels(event.clientX, event.clientY)
+  onMouseMove = (event) => {
+    this.queryCoords(event.clientX, event.clientY)
   }
 
-  queryHeatmapVessels(x, y) {
+  queryCoords(x, y) {
     // bail if all heatmap layers are set to non-interactive
-    if (this.props.heatmapLayers.every(l => l.interactive !== true)) {
+    if (this.props.heatmapLayers.every((l) => l.interactive !== true)) {
       return
     }
 
@@ -173,13 +173,16 @@ class ActivityLayers extends BaseControl {
 
     const toleranceRadiusInWorldUnits = VESSEL_CLICK_TOLERANCE_PX / viewport.scale
 
-    this.props.queryHeatmapVessels({
-      longitude: wrappedLongitude,
-      latitude,
-      worldX,
-      worldY,
-      toleranceRadiusInWorldUnits,
-    })
+    this.props.queryHeatmapVessels(
+      {
+        longitude: wrappedLongitude,
+        latitude,
+        worldX,
+        worldY,
+        toleranceRadiusInWorldUnits,
+      },
+      this.props.temporalExtentIndexes
+    )
   }
 
   _onTick = () => {
@@ -223,16 +226,16 @@ class ActivityLayers extends BaseControl {
       highlightedVessels.foundVessels !== undefined &&
       highlightedVessels.isEmpty !== true
     ) {
-      const sourceLayer = heatmapLayers.find(l => l.id === highlightedVessels.layer.id)
+      const sourceLayer = heatmapLayers.find((l) => l.id === highlightedVessels.layer.id)
       highlightLayerData = { highlightLayerData, ...sourceLayer }
-      highlightFilters = highlightedVessels.foundVessels.map(vessel => ({
+      highlightFilters = highlightedVessels.foundVessels.map((vessel) => ({
         hue,
         filterValues: {
           series: [vessel.series],
         },
       }))
     } else if (highlightedClickedVessel !== null) {
-      const sourceLayer = heatmapLayers.find(l => l.id === highlightedClickedVessel.layer.id)
+      const sourceLayer = heatmapLayers.find((l) => l.id === highlightedClickedVessel.layer.id)
       highlightLayerData = { highlightLayerData, ...sourceLayer }
       highlightFilters = [
         {
@@ -285,14 +288,14 @@ class ActivityLayers extends BaseControl {
 
     return (
       <div
-        ref={ref => {
+        ref={(ref) => {
           this.container = ref
         }}
         style={{ position: 'absolute' }}
         onMouseMove={this.onMouseMove}
         onTouchStart={this.onTouchStart}
       >
-        {heatmapLayers.map(layer => (
+        {heatmapLayers.map((layer) => (
           <HeatmapLayer
             key={layer.id}
             layer={layer}

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -1,57 +1,23 @@
 import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
-import convert from '@globalfishingwatch/map-convert'
 import { mergeDeep, fromJS } from 'immutable'
 import { closePopup } from '../module/module.actions.js'
 import { getTracksStyles } from '../tracks/tracks.selectors.js'
 import { mapHover, mapClick } from './interaction.actions.js'
 import { setViewport, transitionEnd } from './viewport.actions.js'
-import { MIN_FRAME_LENGTH_MS } from '../config'
 import Map from './Map'
 
-const getTemporalExtent = (state, ownProps) => ownProps.temporalExtent
-const getHighlightTemporalExtent = (state, ownProps) => ownProps.highlightTemporalExtent
-const getStaticLayers = state => state.map.style.staticLayers
-
-// TODO MAP MODULE move those selectors to separated actions/reducer
-// thus avoiding passing temporal extents through Map to ActivityLayers
-const getTemporalExtentIndexes = createSelector(
-  [getTemporalExtent],
-  temporalExtent => {
-    const startTimestamp = temporalExtent[0].getTime()
-    const endTimestamp = Math.max(
-      temporalExtent[1].getTime(),
-      temporalExtent[0].getTime() + MIN_FRAME_LENGTH_MS
-    )
-    const startIndex = convert.getOffsetedTimeAtPrecision(startTimestamp)
-    const endIndex = convert.getOffsetedTimeAtPrecision(endTimestamp)
-    return [startIndex, endIndex]
-  }
-)
-
-const getHighlightTemporalExtentIndexes = createSelector(
-  [getHighlightTemporalExtent],
-  highlightTemporalExtent => {
-    if (highlightTemporalExtent === undefined) {
-      return null
-    }
-    const startTimestamp = highlightTemporalExtent[0].getTime()
-    const endTimestamp = highlightTemporalExtent[1].getTime()
-    const startIndex = convert.getOffsetedTimeAtPrecision(startTimestamp)
-    const endIndex = convert.getOffsetedTimeAtPrecision(endTimestamp)
-    return [startIndex, endIndex]
-  }
-)
+const getStaticLayers = (state) => state.map.style.staticLayers
 
 const getInteractiveLayerIds = createSelector(
   [getStaticLayers],
   // Note: here we assume that layer IDs provided with module match the GL layers that should
   // be interactive or not, ie typically the fill layer if a label layer is present
-  staticLayers =>
-    staticLayers.filter(l => l.interactive === true && l.visible === true).map(l => l.id)
+  (staticLayers) =>
+    staticLayers.filter((l) => l.interactive === true && l.visible === true).map((l) => l.id)
 )
 
-const getMapStyles = state => state.map.style.mapStyle
+const getMapStyles = (state) => state.map.style.mapStyle
 const getMapStyle = createSelector(
   [getMapStyles, getTracksStyles],
   (mapStyles, trackStyles) => {
@@ -67,13 +33,11 @@ const mapStateToProps = (state, ownProps) => ({
   minZoom: state.map.viewport.minZoom,
   cursor: state.map.interaction.cursor,
   mapStyle: getMapStyle(state),
-  temporalExtentIndexes: getTemporalExtentIndexes(state, ownProps),
-  highlightTemporalExtentIndexes: getHighlightTemporalExtentIndexes(state, ownProps),
   interactiveLayerIds: getInteractiveLayerIds(state),
 })
 
-const mapDispatchToProps = dispatch => ({
-  setViewport: viewport => {
+const mapDispatchToProps = (dispatch) => ({
+  setViewport: (viewport) => {
     dispatch(setViewport(viewport))
   },
   mapHover: (lat, long, features) => {

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -5,7 +5,7 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import ActivityLayers from '../activity/ActivityLayers.container.js'
 import styles from './map.css'
 
-const PopupWrapper = props => {
+const PopupWrapper = (props) => {
   const { latitude, longitude, children, closeButton, onClose } = props
   return (
     <Popup
@@ -64,15 +64,15 @@ class Map extends React.Component {
     }
   }
 
-  onViewportChange = viewport => {
+  onViewportChange = (viewport) => {
     this.props.setViewport(viewport)
   }
 
-  onHover = event => {
+  onHover = (event) => {
     this.props.mapHover(event.lngLat[1], event.lngLat[0], event.features)
   }
 
-  onClick = event => {
+  onClick = (event) => {
     this.props.mapClick(event.lngLat[1], event.lngLat[0], event.features)
   }
 
@@ -94,7 +94,7 @@ class Map extends React.Component {
       <div
         id="map"
         className={styles.map}
-        ref={ref => {
+        ref={(ref) => {
           this._mapContainerRef = ref
         }}
         onMouseLeave={() => {
@@ -121,11 +121,7 @@ class Map extends React.Component {
           onViewportChange={this.onViewportChange}
           interactiveLayerIds={interactiveLayerIds}
         >
-          <ActivityLayers
-            temporalExtentIndexes={this.props.temporalExtentIndexes}
-            highlightTemporalExtentIndexes={this.props.highlightTemporalExtentIndexes}
-            loadTemporalExtent={this.props.loadTemporalExtent}
-          />
+          <ActivityLayers loadTemporalExtent={this.props.loadTemporalExtent} />
           {clickPopup !== undefined && clickPopup !== null && (
             <PopupWrapper
               latitude={clickPopup.latitude}

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,1 +1,1 @@
-export { default } from './map'
+export { default, targetMapVessel, AVAILABLE_BASEMAPS } from './map'

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -58,12 +58,12 @@ const store = createStore(
   compose(applyMiddleware(thunk))
 )
 
-const throttleApplyTemporalExtent = throttle(temporalExtent => {
+const throttleApplyTemporalExtent = throttle((temporalExtent) => {
   store.dispatch(applyTemporalExtent(temporalExtent))
   store.dispatch(setTemporalExtent(temporalExtent))
 }, 16)
 
-const updateViewportFromIncomingProps = incomingViewport => {
+const updateViewportFromIncomingProps = (incomingViewport) => {
   store.dispatch(
     updateViewport({
       latitude: incomingViewport.center[0],
@@ -76,6 +76,14 @@ const updateViewportFromIncomingProps = incomingViewport => {
 class MapModule extends React.Component {
   state = {
     initialized: false,
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.log(error, errorInfo)
+    this.setState({
+      error: error,
+      errorInfo: errorInfo,
+    })
   }
 
   componentDidMount() {
@@ -172,7 +180,6 @@ class MapModule extends React.Component {
         store.dispatch(updateLayerLoadTemporalExtents(this.props.loadTemporalExtent))
       }
     }
-
     // temporalExtent
     if (this.props.temporalExtent !== undefined && this.props.temporalExtent.length) {
       if (
@@ -211,6 +218,17 @@ class MapModule extends React.Component {
     }
   }
   render() {
+    console.log(this.state.error)
+    if (this.state.error !== undefined) {
+      return (
+        <div>
+          <h2>Map component crashed!</h2>
+          <p className="red">{this.state.error && this.state.error.toString()}</p>
+          <div>Component Stack Error Details:</div>
+          <p className="red">{this.state.errorInfo.componentStack}</p>
+        </div>
+      )
+    }
     // won't render anything before actions in componentDidMount have been triggered
     return this.state.initialized !== true ? null : (
       <Provider store={store}>
@@ -245,8 +263,8 @@ MapModule.propTypes = {
 
 export default MapModule
 
-export const targetMapVessel = id => {
-  const track = store.getState().map.tracks.data.find(t => t.id === id.toString())
+export const targetMapVessel = (id) => {
+  const track = store.getState().map.tracks.data.find((t) => t.id === id.toString())
   store.dispatch(fitToBounds(track.geoBounds))
 
   return track.timelineBounds

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -235,8 +235,8 @@ class MapModule extends React.Component {
     }
   }
   render() {
-    console.log(this.state.error)
     if (this.state.error !== undefined) {
+      console.log(this.state.error)
       return (
         <div>
           <h2>Map component crashed!</h2>

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -11,7 +11,7 @@ import { heatmapLayerTypes, basemapLayerTypes, staticLayerTypes } from './propty
 import { viewportTypes, popupTypes } from './proptypes/shared'
 
 import Map from './glmap/Map.container'
-import { initModule, setTemporalExtent } from './module/module.actions'
+import { initModule, setTemporalExtent, setHighlightTemporalExtent } from './module/module.actions'
 import { fitToBounds, updateViewport, transitionToZoom } from './glmap/viewport.actions'
 import { initStyle, commitStyleUpdates, applyTemporalExtent } from './glmap/style.actions'
 import { updateTracks } from './tracks/tracks.actions'
@@ -189,6 +189,23 @@ class MapModule extends React.Component {
         this.props.temporalExtent[1].getTime() !== prevProps.temporalExtent[1].getTime()
       ) {
         throttleApplyTemporalExtent(this.props.temporalExtent)
+      }
+    }
+
+    // highlightTemporalExtent
+    if (
+      this.props.highlightTemporalExtent !== undefined &&
+      this.props.highlightTemporalExtent.length
+    ) {
+      if (
+        prevProps.highlightTemporalExtent === undefined ||
+        !prevProps.highlightTemporalExtent.length ||
+        this.props.highlightTemporalExtent[0].getTime() !==
+          prevProps.highlightTemporalExtent[0].getTime() ||
+        this.props.highlightTemporalExtent[1].getTime() !==
+          prevProps.highlightTemporalExtent[1].getTime()
+      ) {
+        store.dispatch(setHighlightTemporalExtent(this.props.highlightTemporalExtent))
       }
     }
 

--- a/src/map/module/module.actions.js
+++ b/src/map/module/module.actions.js
@@ -1,9 +1,10 @@
 export const INIT_MODULE = 'INIT_MODULE'
 export const SET_TEMPORAL_EXTENT = 'SET_TEMPORAL_EXTENT'
+export const SET_HIGHLIGHT_TEMPORAL_EXTENT = 'SET_HIGHLIGHT_TEMPORAL_EXTENT'
 export const START_LOADER = 'START_LOADER'
 export const COMPLETE_LOADER = 'COMPLETE_LOADER'
 
-export const initModule = props => dispatch => {
+export const initModule = (props) => (dispatch) => {
   dispatch({
     type: INIT_MODULE,
     payload: props,
@@ -22,7 +23,7 @@ export const startLoader = (dispatch, state) => {
   return loaderId
 }
 
-export const completeLoader = loaderId => (dispatch, getState) => {
+export const completeLoader = (loaderId) => (dispatch, getState) => {
   const state = getState()
   const loaders = Object.assign({}, state.map.module.loaders)
   dispatch({
@@ -57,9 +58,14 @@ export const onViewportChange = () => (dispatch, getState) => {
   })
 }
 
-export const setTemporalExtent = temporalExtent => ({
+export const setTemporalExtent = (temporalExtent) => ({
   type: SET_TEMPORAL_EXTENT,
   payload: temporalExtent,
+})
+
+export const setHighlightTemporalExtent = (highlightTemporalExtent) => ({
+  type: SET_HIGHLIGHT_TEMPORAL_EXTENT,
+  payload: highlightTemporalExtent,
 })
 
 export const closePopup = () => (dispatch, getState) => {

--- a/src/map/module/module.reducer.js
+++ b/src/map/module/module.reducer.js
@@ -5,7 +5,7 @@ import { INIT_MODULE, SET_TEMPORAL_EXTENT, START_LOADER, COMPLETE_LOADER } from 
 const initialState = {
   loaders: null,
   token: undefined,
-  temporalExtent: null,
+  temporalExtent: [new Date(1970), new Date()],
   onViewportChange: undefined,
   onHover: undefined,
   onClick: undefined,
@@ -39,7 +39,7 @@ const moduleReducer = (state = initialState, action) => {
 
     case COMPLETE_LOADER: {
       const loaders = [...state.loaders]
-      const loaderIndex = loaders.findIndex(l => l === action.payload)
+      const loaderIndex = loaders.findIndex((l) => l === action.payload)
       loaders.splice(loaderIndex, 1)
       return { ...state, loaders }
     }

--- a/src/map/module/module.reducer.js
+++ b/src/map/module/module.reducer.js
@@ -1,11 +1,18 @@
 import PropTypes from 'prop-types'
 import withReducerTypes from '../utils/withReducerTypes'
-import { INIT_MODULE, SET_TEMPORAL_EXTENT, START_LOADER, COMPLETE_LOADER } from './module.actions'
+import {
+  INIT_MODULE,
+  SET_TEMPORAL_EXTENT,
+  SET_HIGHLIGHT_TEMPORAL_EXTENT,
+  START_LOADER,
+  COMPLETE_LOADER,
+} from './module.actions'
 
 const initialState = {
   loaders: null,
   token: undefined,
   temporalExtent: [new Date(1970), new Date()],
+  highlightTemporalExtent: null,
   onViewportChange: undefined,
   onHover: undefined,
   onClick: undefined,
@@ -28,6 +35,13 @@ const moduleReducer = (state = initialState, action) => {
       return {
         ...state,
         temporalExtent: action.payload,
+      }
+    }
+
+    case SET_HIGHLIGHT_TEMPORAL_EXTENT: {
+      return {
+        ...state,
+        highlightTemporalExtent: action.payload,
       }
     }
 

--- a/src/map/tracks/tracks.actions.js
+++ b/src/map/tracks/tracks.actions.js
@@ -14,15 +14,15 @@ export const ADD_TRACK = 'ADD_TRACK'
 export const UPDATE_TRACK = 'UPDATE_TRACK'
 export const REMOVE_TRACK = 'REMOVE_TRACK'
 
-const getTrackDataParsed = geojson => {
+const getTrackDataParsed = (geojson) => {
   const time = { start: Infinity, end: 0 }
   if (geojson && geojson.features) {
-    geojson.features.forEach(feature => {
+    geojson.features.forEach((feature) => {
       const hasTimes =
         feature.properties.coordinateProperties.times &&
         feature.properties.coordinateProperties.times.length > 0
       if (hasTimes) {
-        feature.properties.coordinateProperties.times.forEach(datetime => {
+        feature.properties.coordinateProperties.times.forEach((datetime) => {
           if (datetime < time.start) {
             time.start = datetime
           } else if (datetime > time.end) {
@@ -101,7 +101,7 @@ function loadTrack({ id, url, type, fitBoundsOnLoad, layerTemporalExtents, color
   return (dispatch, getState) => {
     const state = getState()
     const loaderID = startLoader(dispatch, state)
-    if (state.map.tracks.data.find(t => t.id === id)) {
+    if (state.map.tracks.data.find((t) => t.id === id)) {
       return
     }
 
@@ -120,7 +120,7 @@ function loadTrack({ id, url, type, fitBoundsOnLoad, layerTemporalExtents, color
       const token = state.map.module.token
       const promises = getTilePromises(url, token, layerTemporalExtents, { seriesgroup: id })
 
-      Promise.all(promises.map(p => p.catch(e => e))).then(rawTileData => {
+      Promise.all(promises.map((p) => p.catch((e) => e))).then((rawTileData) => {
         const cleanData = getCleanVectorArrays(rawTileData)
 
         if (!cleanData.length) {
@@ -151,11 +151,11 @@ function loadTrack({ id, url, type, fitBoundsOnLoad, layerTemporalExtents, color
       })
     } else {
       fetch(url)
-        .then(res => {
+        .then((res) => {
           if (res.status >= 400) throw new Error(res.statusText)
           return res.json()
         })
-        .then(data => {
+        .then((data) => {
           const { geojson, geoBounds, timelineBounds } = getTrackDataParsed(data)
           dispatch({
             type: UPDATE_TRACK,
@@ -164,19 +164,20 @@ function loadTrack({ id, url, type, fitBoundsOnLoad, layerTemporalExtents, color
               data: geojson,
               geoBounds,
               timelineBounds,
+              isGeoJSON: true,
             },
           })
           if (fitBoundsOnLoad) {
             targetMapVessel(id)
           }
         })
-        .catch(err => console.warn(err))
+        .catch((err) => console.warn(err))
         .finally(() => dispatch(completeLoader(loaderID)))
     }
   }
 }
 
-const removeTrack = trackId => ({
+const removeTrack = (trackId) => ({
   type: REMOVE_TRACK,
   payload: {
     trackId,
@@ -187,9 +188,9 @@ export const updateTracks = (newTracks = []) => (dispatch, getState) => {
   const prevTracks = getState().map.tracks.data
   // add and update layers
   if (newTracks) {
-    newTracks.forEach(newTrack => {
+    newTracks.forEach((newTrack) => {
       const trackId = newTrack.id
-      const prevTrack = prevTracks.find(t => t.id === trackId)
+      const prevTrack = prevTracks.find((t) => t.id === trackId)
       if (prevTrack === undefined) {
         dispatch(loadTrack(newTrack))
       } else if (prevTrack.color !== newTrack.color) {
@@ -205,8 +206,8 @@ export const updateTracks = (newTracks = []) => (dispatch, getState) => {
   }
 
   // clean up unused tracks
-  prevTracks.forEach(prevTrack => {
-    if (!newTracks || !newTracks.find(t => t.id === prevTrack.id)) {
+  prevTracks.forEach((prevTrack) => {
+    if (!newTracks || !newTracks.find((t) => t.id === prevTrack.id)) {
       dispatch(removeTrack(prevTrack.id))
     }
   })

--- a/src/map/tracks/tracks.actions.js
+++ b/src/map/tracks/tracks.actions.js
@@ -164,7 +164,6 @@ function loadTrack({ id, url, type, fitBoundsOnLoad, layerTemporalExtents, color
               data: geojson,
               geoBounds,
               timelineBounds,
-              isGeoJSON: true,
             },
           })
           if (fitBoundsOnLoad) {

--- a/src/map/tracks/tracks.reducer.js
+++ b/src/map/tracks/tracks.reducer.js
@@ -50,7 +50,6 @@ const tracksTypes = {
         maxLat: PropTypes.number,
         maxLng: PropTypes.number,
       }),
-      isGeoJSON: PropTypes.bool,
     })
   ),
 }

--- a/src/map/tracks/tracks.reducer.js
+++ b/src/map/tracks/tracks.reducer.js
@@ -17,7 +17,7 @@ const tracksReducer = (state = initialState, action) => {
 
     case UPDATE_TRACK: {
       const trackData = action.payload
-      const data = state.data.map(track => {
+      const data = state.data.map((track) => {
         if (track.id !== trackData.id) return track
         return {
           ...track,
@@ -29,7 +29,7 @@ const tracksReducer = (state = initialState, action) => {
 
     case REMOVE_TRACK: {
       const removedTrackId = action.payload.trackId
-      const data = state.data.filter(track => track.id !== removedTrackId)
+      const data = state.data.filter((track) => track.id !== removedTrackId)
       return { ...state, data }
     }
 
@@ -50,6 +50,7 @@ const tracksTypes = {
         maxLat: PropTypes.number,
         maxLng: PropTypes.number,
       }),
+      isGeoJSON: PropTypes.bool,
     })
   ),
 }

--- a/src/map/tracks/tracks.selectors.js
+++ b/src/map/tracks/tracks.selectors.js
@@ -51,7 +51,7 @@ const filterGeojsonByTimerange = (geojson, { start, end }) => {
 export const getTracksStyles = createSelector(
   [getTemporalExtent, getTracksData],
   (temporalExtent, tracks) => {
-    const filteredTracks = tracks.filter((t) => t.isGeoJSON === true)
+    const filteredTracks = tracks.filter((t) => t.type === 'geojson')
     const hasTemporalExtent = temporalExtent && temporalExtent.length > 0
     const hasTracks = filteredTracks && filteredTracks.length > 0
     if (!hasTemporalExtent || !hasTracks) return null

--- a/src/map/tracks/tracks.selectors.js
+++ b/src/map/tracks/tracks.selectors.js
@@ -51,7 +51,6 @@ const filterGeojsonByTimerange = (geojson, { start, end }) => {
 export const getTracksStyles = createSelector(
   [getTemporalExtent, getTracksData],
   (temporalExtent, tracks) => {
-    console.log(tracks)
     const filteredTracks = tracks.filter((t) => t.isGeoJSON === true)
     const hasTemporalExtent = temporalExtent && temporalExtent.length > 0
     const hasTracks = filteredTracks && filteredTracks.length > 0

--- a/src/map/tracks/tracks.selectors.js
+++ b/src/map/tracks/tracks.selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
 import { getTemporalExtent } from '../module/module.selectors.js'
 
-export const getTracksData = state => state.map.tracks.data
+export const getTracksData = (state) => state.map.tracks.data
 
 const filterGeojsonByTimerange = (geojson, { start, end }) => {
   if (!geojson || !geojson.features) return null
@@ -51,15 +51,17 @@ const filterGeojsonByTimerange = (geojson, { start, end }) => {
 export const getTracksStyles = createSelector(
   [getTemporalExtent, getTracksData],
   (temporalExtent, tracks) => {
+    console.log(tracks)
+    const filteredTracks = tracks.filter((t) => t.isGeoJSON === true)
     const hasTemporalExtent = temporalExtent && temporalExtent.length > 0
-    const hasTracks = tracks && tracks.length > 0
+    const hasTracks = filteredTracks && filteredTracks.length > 0
     if (!hasTemporalExtent || !hasTracks) return null
 
     const timerange = {
       start: temporalExtent[0].getTime(),
       end: temporalExtent[1].getTime(),
     }
-    const styles = tracks.reduce(
+    const styles = filteredTracks.reduce(
       (acc, track) => {
         if (!track.data) return acc
 


### PR DESCRIPTION
Makes `temporalExtent` optional. 
`temporalExtent` and `highlightTemporalExtent` used to be passed by Map to ActivityLayers, now taken directly from module reducer.