### PR TITLE
Map tracks highlight

### DIFF
--- a/sandbox/src/map/map.js
+++ b/sandbox/src/map/map.js
@@ -51,6 +51,7 @@ class MapPage extends Component {
   }
 
   render() {
+    const { highlightTemporalExtent } = this.state
     return (
       <div>
         <MapModule
@@ -58,7 +59,7 @@ class MapPage extends Component {
           viewport={this.viewport}
           temporalExtent={this.temporalExtent}
           loadTemporalExtent={this.loadTemporalExtent}
-          highlightTemporalExtent={this.state.highlightTemporalExtent}
+          highlightTemporalExtent={highlightTemporalExtent}
           onViewportChange={this.onViewportChange}
           staticLayers={[]}
         />

--- a/sandbox/src/map/map.js
+++ b/sandbox/src/map/map.js
@@ -3,24 +3,63 @@ import React, { Component } from 'react'
 import MapModule from '@globalfishingwatch/map-components/src/map'
 
 class MapPage extends Component {
-  loadTemporalExtent = [new Date(2018, 0, 1), new Date(2018, 11, 31)]
-  temporalExtent = [new Date(2018, 0, 1), new Date(2018, 11, 31)]
-  viewport = {
-    center: [0.026, 123.61],
-    zoom: 5,
+  constructor(props) {
+    super(props)
+    this.state = {
+      highlightTemporalExtent: [new Date(2017, 11, 1), new Date(2017, 11, 31)],
+      viewport: {
+        center: [0.026, 123.61],
+        zoom: 5,
+      },
+    }
+  }
+  loadTemporalExtent = [new Date(2017, 12, 1), new Date(2017, 11, 31)]
+  temporalExtent = [new Date(2017, 11, 1), new Date(2017, 11, 31)]
+  tracks = [
+    {
+      id: 'dsadfafda8',
+      url:
+        'https://vessels-dot-world-fishing-827.appspot.com/datasets/indonesia/vessels/61d64d171-18a0-8c02-0606-28a5ce540077/tracks',
+      color: '#FE81EB',
+      type: 'geojson',
+      fitBoundsOnLoad: true,
+    },
+  ]
+
+  componentDidMount = () => {
+    setInterval(this.increaseHighlightDay, 1000)
+  }
+
+  componentDidUpdate = () => {
+    if (this.state.highlightTemporalExtent[0].getDate() < 31) {
+      clearInterval(this.increaseHighlightDay)
+    }
+  }
+
+  increaseHighlightDay = () => {
+    const date = this.state.highlightTemporalExtent[0]
+    const year = date.getFullYear()
+    const month = date.getMonth()
+    const newDay = date.getDate() + 1
+    this.setState((state) => ({
+      highlightTemporalExtent: [new Date(year, month, newDay), state.highlightTemporalExtent[1]],
+    }))
+  }
+
+  onViewportChange = ({ zoom, center }) => {
+    this.setState({ zoom, center })
   }
 
   render() {
     return (
       <div>
         <MapModule
-          tracks={[]}
+          tracks={this.tracks}
           viewport={this.viewport}
           temporalExtent={this.temporalExtent}
           loadTemporalExtent={this.loadTemporalExtent}
-          onViewportChange={(a, b, c) => {
-            console.log(a, b, c)
-          }}
+          highlightTemporalExtent={this.state.highlightTemporalExtent}
+          onViewportChange={this.onViewportChange}
           staticLayers={[]}
         />
       </div>

--- a/sandbox/src/timebar/timebar.css
+++ b/sandbox/src/timebar/timebar.css
@@ -4,7 +4,7 @@
   bottom: 0;
 }
 
-.humanizedTimeSpan {
+.dates {
   font-family: 'Roboto', sans-serif;
   text-transform: uppercase;
   font-size: 14px;

--- a/sandbox/src/timebar/timebar.js
+++ b/sandbox/src/timebar/timebar.js
@@ -13,7 +13,7 @@ import Timebar, {
 
 import './timebar.css'
 
-const HOVER_DELTA = 50
+const HOVER_DELTA = 10
 
 // --- TODO This should be inside Activity.jsx - let's have charts deal with data formats
 const maxActivity = activityMock.reduce((acc, current) => Math.max(acc, current.value), 0)
@@ -68,9 +68,12 @@ class TimebarContainer extends Component {
   }
 
   onMouseMove = (clientX, scale) => {
-    const startRange = scale(clientX + HOVER_DELTA)
-    const endRange = scale(clientX - HOVER_DELTA)
-    console.log('Range', [startRange, endRange])
+    const hoverStart = scale(clientX - HOVER_DELTA)
+    const hoverEnd = scale(clientX + HOVER_DELTA)
+    this.setState({
+      hoverStart,
+      hoverEnd,
+    })
   }
 
   updateBookmark = (bookmarkStart, bookmarkEnd) => {
@@ -96,6 +99,8 @@ class TimebarContainer extends Component {
       humanizedEnd,
       currentChart,
       highlightedEventIDs,
+      hoverStart,
+      hoverEnd,
     } = this.state
     return (
       <div className="mainContainer">
@@ -135,7 +140,9 @@ class TimebarContainer extends Component {
           >
             Hover to highlight encounter events
           </button>
-          <div className="humanizedTimeSpan">{`${humanizedStart} - ${humanizedEnd}`}</div>
+          <div className="dates">{`${humanizedStart} - ${humanizedEnd}`}</div>
+          <div className="dates">hover start: {hoverStart && hoverStart.toString()}</div>
+          <div className="dates">hover end: {hoverStart && hoverEnd.toString()}</div>
         </div>
         <Timebar
           start={start}

--- a/sandbox/src/timebar/timebar.js
+++ b/sandbox/src/timebar/timebar.js
@@ -13,6 +13,8 @@ import Timebar, {
 
 import './timebar.css'
 
+const HOVER_DELTA = 50
+
 // --- TODO This should be inside Activity.jsx - let's have charts deal with data formats
 const maxActivity = activityMock.reduce((acc, current) => Math.max(acc, current.value), 0)
 // const activity = {};
@@ -63,6 +65,12 @@ class TimebarContainer extends Component {
       humanizedStart,
       humanizedEnd,
     })
+  }
+
+  onMouseMove = (clientX, scale) => {
+    const startRange = scale(clientX + HOVER_DELTA)
+    const endRange = scale(clientX - HOVER_DELTA)
+    console.log('Range', [startRange, endRange])
   }
 
   updateBookmark = (bookmarkStart, bookmarkEnd) => {
@@ -138,6 +146,7 @@ class TimebarContainer extends Component {
           bookmarkEnd={bookmarkEnd}
           // enablePlayback
           onChange={this.update}
+          onMouseMove={this.onMouseMove}
           onBookmarkChange={this.updateBookmark}
         >
           {// props => [

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -49,7 +49,11 @@ const getTemporalExtentIndexes = createSelector(
 const getHighlightTemporalExtentIndexes = createSelector(
   [getHighlightTemporalExtent],
   (highlightTemporalExtent) => {
-    if (highlightTemporalExtent === undefined || highlightTemporalExtent === null) {
+    if (
+      highlightTemporalExtent === undefined ||
+      highlightTemporalExtent === null ||
+      !highlightTemporalExtent.length
+    ) {
       return null
     }
     const startTimestamp = highlightTemporalExtent[0].getTime()

--- a/src/map/activity/ActivityLayers.container.js
+++ b/src/map/activity/ActivityLayers.container.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
 import convert from '@globalfishingwatch/map-convert'
 import { exportNativeViewport } from '../glmap/viewport.actions'
+import { getTemporalExtent, getHighlightTemporalExtent } from '../module/module.selectors'
 import ActivityLayers from './ActivityLayers'
 import { queryHeatmapVessels } from '../heatmap/heatmapTiles.actions'
 import { MIN_FRAME_LENGTH_MS } from '../config'
@@ -30,9 +31,6 @@ const getTracksWithData = createSelector(
     return tracksWithData
   }
 )
-
-const getTemporalExtent = (state) => state.map.module.temporalExtent
-const getHighlightTemporalExtent = (state) => state.map.module.highlightTemporalExtent
 
 const getTemporalExtentIndexes = createSelector(
   [getTemporalExtent],

--- a/src/map/glmap/interaction.actions.js
+++ b/src/map/glmap/interaction.actions.js
@@ -100,10 +100,12 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
     }
   }
 
-  dispatch({
-    type: SET_MAP_CURSOR,
-    payload: cursor,
-  })
+  if (cursor !== state.interaction.cursor) {
+    dispatch({
+      type: SET_MAP_CURSOR,
+      payload: cursor,
+    })
+  }
 
   if (state.module.onHover) {
     state.module.onHover({

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -36,7 +36,10 @@ const mapReducer = combineReducers({
 
 let composeEnhancers = compose
 
-if (process.env.MAP_REDUX_REMOTE_DEBUG && process.env.NODE_ENV === 'development') {
+if (
+  (process.env.MAP_REDUX_REMOTE_DEBUG || process.env.REACT_APP_MAP_REDUX_REMOTE_DEBUG) &&
+  process.env.NODE_ENV === 'development'
+) {
   const composeWithDevTools = require('remote-redux-devtools').composeWithDevTools
   composeEnhancers = composeWithDevTools({
     name: 'Map module',
@@ -119,6 +122,13 @@ class MapModule extends React.Component {
           onAttributionsChange: this.props.onAttributionsChange,
         })
       )
+    }
+
+    if (
+      this.props.highlightTemporalExtent !== undefined &&
+      this.props.highlightTemporalExtent.length
+    ) {
+      store.dispatch(setHighlightTemporalExtent(this.props.highlightTemporalExtent))
     }
 
     if (

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -124,10 +124,7 @@ class MapModule extends React.Component {
       )
     }
 
-    if (
-      this.props.highlightTemporalExtent !== undefined &&
-      this.props.highlightTemporalExtent.length
-    ) {
+    if (this.props.highlightTemporalExtent !== null && this.props.highlightTemporalExtent.length) {
       store.dispatch(setHighlightTemporalExtent(this.props.highlightTemporalExtent))
     }
 
@@ -201,18 +198,19 @@ class MapModule extends React.Component {
     }
 
     // highlightTemporalExtent
-    if (
-      this.props.highlightTemporalExtent !== undefined &&
-      this.props.highlightTemporalExtent.length
-    ) {
+    if (this.props.highlightTemporalExtent !== null && this.props.highlightTemporalExtent.length) {
       if (
-        prevProps.highlightTemporalExtent === undefined ||
+        prevProps.highlightTemporalExtent === null ||
         !prevProps.highlightTemporalExtent.length ||
         this.props.highlightTemporalExtent[0].getTime() !==
           prevProps.highlightTemporalExtent[0].getTime() ||
         this.props.highlightTemporalExtent[1].getTime() !==
           prevProps.highlightTemporalExtent[1].getTime()
       ) {
+        store.dispatch(setHighlightTemporalExtent(this.props.highlightTemporalExtent))
+      }
+    } else {
+      if (this.props.highlightTemporalExtent !== prevProps.highlightTemporalExtent) {
         store.dispatch(setHighlightTemporalExtent(this.props.highlightTemporalExtent))
       }
     }
@@ -284,6 +282,10 @@ MapModule.propTypes = {
   onHover: PropTypes.func,
   onAttributionsChange: PropTypes.func,
   onClosePopup: PropTypes.func,
+}
+
+MapModule.defaultProps = {
+  highlightTemporalExtent: null,
 }
 
 export default MapModule

--- a/src/map/module/module.selectors.js
+++ b/src/map/module/module.selectors.js
@@ -1,1 +1,3 @@
 export const getTemporalExtent = (state) => state.map.module.temporalExtent
+
+export const getHighlightTemporalExtent = (state) => state.map.module.highlightTemporalExtent

--- a/src/map/tracks/tracks.selectors.js
+++ b/src/map/tracks/tracks.selectors.js
@@ -89,7 +89,6 @@ const getFullTracksStyles = createSelector(
               id: `${track.id}Lines`,
               source,
               type: 'line',
-              layout: {},
               paint: {
                 'line-width': 1,
                 'line-color': track.color,
@@ -100,7 +99,6 @@ const getFullTracksStyles = createSelector(
               source,
               type: 'circle',
               filter: ['match', ['geometry-type'], ['', 'Point'], true, false],
-              layout: {},
               paint: {
                 'circle-radius': 4,
                 'circle-color': track.color,
@@ -144,7 +142,6 @@ const getHighlightedTrackStyles = createSelector(
               id: `${track.id}HighlightedLines`,
               source,
               type: 'line',
-              layout: {},
               paint: {
                 'line-width': 1,
                 'line-color': '#fff',

--- a/src/timebar/components/timeline.js
+++ b/src/timebar/components/timeline.js
@@ -159,7 +159,7 @@ class Timeline extends Component {
     const x = clientX - outerX
     const isMovingInside = this.node.contains(event.target)
     if (isMovingInside) {
-      this.throttledMouseMove(x, this.innerScale.invert)
+      this.throttledMouseMove(x, this.outerScale.invert)
     }
     if (dragging === DRAG_INNER) {
       const currentDeltaMs = getDeltaMs(start, end)
@@ -255,7 +255,7 @@ class Timeline extends Component {
     const outerStart = this.innerScale.invert(-innerStartPx).toISOString()
     const outerEnd = this.innerScale.invert(outerWidth - innerStartPx).toISOString()
 
-    const outerScale = scaleTime()
+    this.outerScale = scaleTime()
       .domain([new Date(outerStart), new Date(outerEnd)])
       .range([0, this.state.outerWidth])
 
@@ -265,7 +265,7 @@ class Timeline extends Component {
       <div ref={(node) => (this.node = node)} className={styles.Timeline}>
         {bookmarkStart !== undefined && bookmarkStart !== null && (
           <Bookmark
-            scale={outerScale}
+            scale={this.outerScale}
             bookmarkStart={bookmarkStart}
             bookmarkEnd={bookmarkEnd}
             minX={-outerX}
@@ -297,14 +297,14 @@ class Timeline extends Component {
           >
             <TimelineUnits
               {...this.props}
-              outerScale={outerScale}
+              outerScale={this.outerScale}
               outerStart={outerStart}
               outerEnd={outerEnd}
               immediate={immediate}
             />
             {this.props.children &&
               this.props.children({
-                outerScale,
+                outerScale: this.outerScale,
                 outerStart,
                 outerEnd,
                 outerWidth,
@@ -354,7 +354,7 @@ class Timeline extends Component {
             width: dragging === DRAG_END ? outerWidth - handlerMouseX : outerWidth - innerEndPx,
           }}
         />
-        <Spring native immediate={immediate} to={{ left: outerScale(new Date(absoluteEnd)) }}>
+        <Spring native immediate={immediate} to={{ left: this.outerScale(new Date(absoluteEnd)) }}>
           {(style) => (
             <animated.div className={styles.absoluteEnd} style={style}>
               <div className={styles.lastUpdateLabel}>Last Update</div>


### PR DESCRIPTION
This PR includes two related features:
- Tracks map [(example)](https://github.com/GlobalFishingWatch/map-components/compare/map-tracks-highlight?expand=1#diff-48660cca802f28d5906c81f9e9e28e8aR9): highlight partial track depending on `highlightTemporalExtent` prop. 
- Timeline [(example)](https://github.com/GlobalFishingWatch/map-components/compare/map-tracks-highlight?expand=1#diff-21da8f2c0ccdc342c46268f915ee2dcbR71): add `onMouseMove` callback prop sending two params: 
  - posX of the event
  - scale to convert `x` positions to date

Fixes:
- how to reset the `highlightTemporalExtent` prop in the map. 
I think worth it to add `defaultProps` to map component because it allows us to stop using `!== undefined` and makes us able to check using `!==null` 
- avoid spamming the SET_MAP_CURSOR action, being now dispatched only when it changes.

And finally, the map redux_remote_debug option will be available when working on the sandbox with the .env variable `REACT_APP_MAP_REDUX_REMOTE_DEBUG` 


