### PR TITLE
Properties in hover and click map events

### DIFF
--- a/src/map/glmap/interaction.actions.js
+++ b/src/map/glmap/interaction.actions.js
@@ -59,12 +59,13 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
     type: null,
   }
 
+  let properties = {}
   if (isEmpty === true) {
     const feature = findFeature(features, null)
     if (feature !== undefined) {
       const popupFields = getFeatureMetaFields(feature.staticLayerId, state, feature.feature)
       if (popupFields !== null) {
-        const properties = feature.feature.properties
+        properties = feature.feature.properties
         const mainPopupField =
           popupFields.find((f) => f.id && f.id.toLowerCase() === 'name') ||
           popupFields.find((f) => f.id && f.id.toLowerCase() === 'id') ||
@@ -112,6 +113,7 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
       ...event,
       latitude,
       longitude,
+      properties,
     })
   }
 }
@@ -129,12 +131,13 @@ export const mapClick = (latitude, longitude, features) => (dispatch, getState) 
     type: null,
   }
 
+  let properties = {}
   if (isEmpty === true) {
     const feature = findFeature(features, null)
     if (feature !== undefined) {
       const metaFields = getFeatureMetaFields(feature.staticLayerId, state, feature.feature)
       let fields
-      const properties = feature.feature.properties
+      properties = feature.feature.properties
       if (metaFields !== null) {
         fields = metaFields.map((metaField) => {
           const id = metaField.id || metaField
@@ -175,6 +178,7 @@ export const mapClick = (latitude, longitude, features) => (dispatch, getState) 
       ...event,
       latitude,
       longitude,
+      properties,
     })
   }
 }

--- a/src/map/glmap/interaction.actions.js
+++ b/src/map/glmap/interaction.actions.js
@@ -59,13 +59,12 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
     type: null,
   }
 
-  let properties = {}
   if (isEmpty === true) {
     const feature = findFeature(features, null)
     if (feature !== undefined) {
       const popupFields = getFeatureMetaFields(feature.staticLayerId, state, feature.feature)
       if (popupFields !== null) {
-        properties = feature.feature.properties
+        const properties = feature.feature.properties
         const mainPopupField =
           popupFields.find((f) => f.id && f.id.toLowerCase() === 'name') ||
           popupFields.find((f) => f.id && f.id.toLowerCase() === 'id') ||
@@ -84,6 +83,7 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
         }
         event.target = {
           featureTitle,
+          properties,
         }
         cursor = 'pointer'
       }
@@ -113,7 +113,6 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
       ...event,
       latitude,
       longitude,
-      properties,
     })
   }
 }
@@ -131,13 +130,12 @@ export const mapClick = (latitude, longitude, features) => (dispatch, getState) 
     type: null,
   }
 
-  let properties = {}
   if (isEmpty === true) {
     const feature = findFeature(features, null)
     if (feature !== undefined) {
       const metaFields = getFeatureMetaFields(feature.staticLayerId, state, feature.feature)
       let fields
-      properties = feature.feature.properties
+      const properties = feature.feature.properties
       if (metaFields !== null) {
         fields = metaFields.map((metaField) => {
           const id = metaField.id || metaField
@@ -178,7 +176,6 @@ export const mapClick = (latitude, longitude, features) => (dispatch, getState) 
       ...event,
       latitude,
       longitude,
-      properties,
     })
   }
 }


### PR DESCRIPTION
This PR includes the event properties in the `hover` and `click` map events.

I have the doubt on what is best to send when is not empty. Do you prefer an empty object, a null or an undefined? I used an empty object to make it easier to check nested properties, but please let me know your thoughts.