### PR TITLE
Make url track data optional

### DIFF
--- a/sandbox/src/timebar/timebar.js
+++ b/sandbox/src/timebar/timebar.js
@@ -110,6 +110,7 @@ class TimebarContainer extends Component {
               onChange={(event) => {
                 this.setState({ currentChart: event.target.value })
               }}
+              value={currentChart}
             >
               <option value="activity">Activity</option>
               <option value="events">Events</option>

--- a/src/map/proptypes/tracks.js
+++ b/src/map/proptypes/tracks.js
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types'
 
 export const trackTypes = {
   id: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
+  data: PropTypes.object,
   color: PropTypes.string,
   type: PropTypes.oneOf(['geojson', undefined]),
   layerTemporalExtents: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),

--- a/src/map/tracks/tracks.actions.js
+++ b/src/map/tracks/tracks.actions.js
@@ -113,12 +113,13 @@ function loadTrack(track) {
       fitBoundsOnLoad,
     }
     const trackHasData = track.data !== undefined && track.data !== null
+    const trackHasUrl = url !== undefined && url !== null && url !== ''
     if (trackHasData) {
       payload.data = data
     }
     dispatch({ type: ADD_TRACK, payload })
 
-    if (!trackHasData && url) {
+    if (!trackHasData && trackHasUrl) {
       const loaderID = startLoader(dispatch, state)
       if (type !== 'geojson') {
         // Deprecated tracks format logic to be deleted some day


### PR DESCRIPTION
As we need the track geojson data in the data portal and in order to avoid multiple API request, this PR includes support to pass the track data directly in the prop in the object attribute `data`.
So now url and data are now optionals, but one of them has to be there.