### PR TITLE
fix timebar events hover

### DIFF
--- a/src/timebar/components/timeline.module.css
+++ b/src/timebar/components/timeline.module.css
@@ -16,19 +16,6 @@
   position: relative;
   height: 100%;
   display: flex;
-}
-
-.overlays {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: flex;
-}
-
-.hoverArea {
-  flex: 1;
   cursor: move; /* fallback if grab cursor is unsupported */
   cursor: grab;
   cursor: -moz-grab;
@@ -36,10 +23,12 @@
 }
 
 .veil {
+  position: absolute;
   height: 100%;
   top: 0;
   transition: var(--timebar-hover-transition);
   z-index: 1;
+  pointer-events: all;
 }
 
 .veilLeft {


### PR DESCRIPTION
This PR reverts https://github.com/GlobalFishingWatch/map-components/pull/31 as it broke the events hover feature and use a different approach to calculate when the mouse is inside the graph area.
It uses the `innerStartPx` and `innerEndPx` to check instead of a dom element node on top of it