### PR TITLE
Selected event highlight without tooltip

### DIFF
--- a/src/timebar/charts/vessel-events.js
+++ b/src/timebar/charts/vessel-events.js
@@ -9,7 +9,6 @@ import { ReactComponent as IconEncounter } from '../icons/events/encounter.svg'
 import { ReactComponent as IconUnregistered } from '../icons/events/unregistered.svg'
 import { ReactComponent as IconGap } from '../icons/events/gap.svg'
 import { ReactComponent as IconPort } from '../icons/events/port.svg'
-import { finished } from 'stream'
 
 const ICONS = {
   encounter: <IconEncounter />,
@@ -71,11 +70,16 @@ class VesselEvents extends Component {
     }))
   })
 
-  addHighlightInfo = memoize((events, highlightedEventIDs) => {
-    const eventsWithHighlight = events.map((event) => ({
-      ...event,
-      isHighlighted: highlightedEventIDs !== null && highlightedEventIDs.indexOf(event.id) > -1,
-    }))
+  addHighlightInfo = memoize((events, highlightedEventIDs, selectedEventID) => {
+    const eventsWithHighlight = events.map((event) => {
+      const isHighlighted =
+        (highlightedEventIDs !== null && highlightedEventIDs.indexOf(event.id) > -1) ||
+        (selectedEventID !== null && selectedEventID === event.id)
+      return {
+        ...event,
+        isHighlighted,
+      }
+    })
 
     const highlighted = [
       ...eventsWithHighlight.filter((event) => event.isHighlighted === false),
@@ -213,6 +217,7 @@ class VesselEvents extends Component {
   render() {
     const {
       events,
+      selectedEventID,
       highlightedEventIDs,
       outerStart,
       outerEnd,
@@ -222,7 +227,11 @@ class VesselEvents extends Component {
       tooltipContainer,
     } = this.props
 
-    const preparedEvents = this.addHighlightInfo(this.getEvents(events), highlightedEventIDs)
+    const preparedEvents = this.addHighlightInfo(
+      this.getEvents(events),
+      highlightedEventIDs,
+      selectedEventID
+    )
     const filteredEvents = this.filterEvents(preparedEvents, outerStart, outerEnd)
     const backgrounds = this.getBackgrounds(filteredEvents)
     const lines = this.getLines(filteredEvents)
@@ -296,6 +305,7 @@ VesselEvents.propTypes = {
       type: PropTypes.string,
     })
   ).isRequired,
+  selectedEventID: PropTypes.string,
   highlightedEventIDs: PropTypes.arrayOf(PropTypes.string),
   outerScale: PropTypes.func.isRequired,
   outerWidth: PropTypes.number.isRequired,
@@ -305,7 +315,8 @@ VesselEvents.propTypes = {
 }
 
 VesselEvents.defaultProps = {
-  highlightedEventIDs: null,
+  selectedEventID: null,
+  highlightedEventID: null,
 }
 
 export default VesselEvents

--- a/src/timebar/charts/vessel-events.js
+++ b/src/timebar/charts/vessel-events.js
@@ -320,7 +320,7 @@ VesselEvents.propTypes = {
 
 VesselEvents.defaultProps = {
   selectedEventID: null,
-  highlightedEventID: null,
+  highlightedEventIDs: null,
   onEventHighlighted: () => {},
   onEventClick: () => {},
 }

--- a/src/timebar/charts/vessel-events.js
+++ b/src/timebar/charts/vessel-events.js
@@ -223,6 +223,7 @@ class VesselEvents extends Component {
       outerEnd,
       outerWidth,
       graphHeight,
+      onEventClick,
       onEventHighlighted,
       tooltipContainer,
     } = this.props
@@ -276,6 +277,7 @@ class VesselEvents extends Component {
                 key={props.event.uid || props.event.id}
                 onMouseEnter={() => onEventHighlighted(props.event)}
                 onMouseLeave={() => onEventHighlighted()}
+                onClick={() => onEventClick(props.event)}
               >
                 <rect
                   x={props.style.x1}
@@ -308,6 +310,8 @@ VesselEvents.propTypes = {
   selectedEventID: PropTypes.string,
   highlightedEventIDs: PropTypes.arrayOf(PropTypes.string),
   outerScale: PropTypes.func.isRequired,
+  onEventHighlighted: PropTypes.func,
+  onEventClick: PropTypes.func,
   outerWidth: PropTypes.number.isRequired,
   outerHeight: PropTypes.number.isRequired,
   graphHeight: PropTypes.number.isRequired,
@@ -317,6 +321,8 @@ VesselEvents.propTypes = {
 VesselEvents.defaultProps = {
   selectedEventID: null,
   highlightedEventID: null,
+  onEventHighlighted: () => {},
+  onEventClick: () => {},
 }
 
 export default VesselEvents


### PR DESCRIPTION
Allows highlighting an event without showing the tooltip.

![image](https://user-images.githubusercontent.com/10500650/55339859-cac7b980-54a3-11e9-9878-e525e0c90b8b.png)
