### PR TITLE
Fix minify

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "memoize-one": "^5.0.0",
     "pbf": "^3.2.0",
     "prop-types": "^15.6.2",
-    "react-spring": "^7.2.10",
+    "react-spring": "^8.0.19",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "topojson-client": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,6 +41,6 @@ export default {
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
     }),
     bundleVisualizer && visualizer({ title: 'GFW Components bundle sizes' }),
-    // isProduction && terser(),
+    isProduction && terser(),
   ],
 }

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -36,21 +36,20 @@ const mapReducer = combineReducers({
 
 let composeEnhancers = compose
 
-// TODO: use when minify fixed as we want to get rid of remote-redux-devtools on production
-// if (
-//   (process.env.MAP_REDUX_REMOTE_DEBUG || process.env.REACT_APP_MAP_REDUX_REMOTE_DEBUG) &&
-//   process.env.NODE_ENV === 'development'
-// ) {
-//   const composeWithDevTools = require('remote-redux-devtools').composeWithDevTools
-//   composeEnhancers = composeWithDevTools({
-//     name: 'Map module',
-//     realtime: true,
-//     hostname: 'localhost',
-//     port: 8000,
-//     maxAge: 30,
-//     stateSanitizer: (state) => ({ ...state, map: { ...state.map, heatmap: 'NOT_SERIALIZED' } }),
-//   })
-// }
+if (
+  (process.env.MAP_REDUX_REMOTE_DEBUG || process.env.REACT_APP_MAP_REDUX_REMOTE_DEBUG) &&
+  process.env.NODE_ENV === 'development'
+) {
+  const composeWithDevTools = require('remote-redux-devtools').composeWithDevTools
+  composeEnhancers = composeWithDevTools({
+    name: 'Map module',
+    realtime: true,
+    hostname: 'localhost',
+    port: 8000,
+    maxAge: 30,
+    stateSanitizer: (state) => ({ ...state, map: { ...state.map, heatmap: 'NOT_SERIALIZED' } }),
+  })
+}
 
 const store = createStore(
   combineReducers({

--- a/src/timebar/charts/activity.js
+++ b/src/timebar/charts/activity.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { area, curveStepAfter } from 'd3-shape'
-import { animated, Spring } from 'react-spring'
+import { animated, Spring } from 'react-spring/renderprops'
 import { getTime } from '../utils'
 import styles from './activity.module.css'
 

--- a/src/timebar/components/timeline-units.js
+++ b/src/timebar/components/timeline-units.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import dayjs from 'dayjs'
-import { animated, Transition } from 'react-spring'
+import { animated, Transition } from 'react-spring/renderprops'
 import { getTime, getDeltaDays } from '../utils'
 import styles from './timeline-units.module.css'
 

--- a/src/timebar/components/timeline.js
+++ b/src/timebar/components/timeline.js
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { scaleTime } from 'd3-scale'
 import dayjs from 'dayjs'
 import throttle from 'lodash/throttle'
-import { animated, Spring } from 'react-spring'
+import { animated, Spring } from 'react-spring/renderprops'
 import {
   getTime,
   clampToAbsoluteBoundaries,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13737,12 +13737,12 @@ react-sizes@^1.0.4:
     lodash.throttle "^4.1.1"
     prop-types "^15.6.0"
 
-react-spring@^7.2.10:
-  version "7.2.11"
-  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-7.2.11.tgz#90962121c925c8a3181801b926eaf94c9b5c942e"
-  integrity sha512-VHoN34MTZFkvamy7Vlmcx2HR5WVSuaQQjFNlVRNyWNi+rcjYT8OcsggzeDltFycseBh8cZveYTc/iPCEe6O0Sw==
+react-spring@^8.0.19:
+  version "8.0.19"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.19.tgz#62f4f396b4b73fa402838200a1c80374338cb12e"
+  integrity sha512-DjrwjXqqVEitj6e6GqdW5dUp1BoVyeFQhEcXvPfoQxwyIVSJ9smNt8CNjSvoQqRujVllE7XKaJRWSZO/ewd1/A==
   dependencies:
-    "@babel/runtime" "^7.0.0"
+    "@babel/runtime" "^7.3.1"
 
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Using the latest version of react-spring and the `renderprops` entry point rollup knows how to resolve those imports and the minified version of the bundle works!

This PR fixes it and minify code for production and restore the redux-devtools for the map