### PR TITLE
Static layers custom tiles urls

### DIFF
--- a/sandbox/src/map/map.js
+++ b/sandbox/src/map/map.js
@@ -151,7 +151,7 @@ class MapPage extends Component {
           center: map.center,
           zoom: map.zoom,
         },
-        staticLayers: layers.filter((l) => l.type === 'CartoDBAnimation'),
+        staticLayers: layers,
       },
     })
   }

--- a/src/map/README.md
+++ b/src/map/README.md
@@ -1,6 +1,7 @@
 # GlobalFishingWatch Map Module
 
 This is a JavaScript module used to display and load fishing activity and fishing-related layers on a map, used in various GFW projects:
+
 - <a href="https://github.com/GlobalFishingWatch/map-client">GlobalFishingWatch main client</a>
 - <a href="https://github.com/GlobalFishingWatch/data-portal">Fishing events data portal</a>
 - Upcoming GFW projects: labeling tool, carrier database portal, etc
@@ -8,6 +9,7 @@ This is a JavaScript module used to display and load fishing activity and fishin
 It is usable as a React component (a wrapper around `react-map-gl`).
 
 This module is responsible for:
+
 - displaying a Mapbox GL map, including panning, zooming, etc. Managing map viewport. Managing Mapbox GL JSON style;
 - loading, displaying, and animating Activity Layers (layers with a time dimension):
   - Vessel Tracks
@@ -17,8 +19,8 @@ This module is responsible for:
 - loading and displaying Static layers and Basemap layers (native Mapbox layers) through GL JSON style;
 - dealing with user interaction on the map (highlight on hover and emitting events on hover/click).
 
-
 This module does not deal with:
+
 - workspaces import/export;
 - authentication;
 - layer headers;
@@ -64,7 +66,7 @@ String. Mandatory. Identifies track uniquely, should be UVI or seriesgroup (depr
 
 ### `track.segmentId`
 
-[NOT IMPLEMENTED] [DEPRECATED] String. Formerly `series`
+[NOT IMPLEMENTED][deprecated] String. Formerly `series`
 
 ### `track.url`
 
@@ -123,11 +125,11 @@ Boolean.
 
 Object. Mandatory. Must be passed as is - mandatory fields are:
 
-  - `endpoints` PropTypes.object,
-  - `isPBF` PropTypes.bool,
-  - `colsByName` PropTypes.object,
-  - `temporalExtents` PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
-  - `temporalExtentsLess` PropTypes.bool
+- `endpoints` PropTypes.object,
+- `isPBF` PropTypes.bool,
+- `colsByName` PropTypes.object,
+- `temporalExtents` PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
+- `temporalExtentsLess` PropTypes.bool
 
 ### `heatmapLayer.interactive`
 
@@ -136,6 +138,7 @@ Boolean. Whether interaction is active on the layer or not. [PARTIALLY IMPLEMENT
 ## `heatmapLayer.filters`
 
 An array of filters. Heatmap filters are defined as:
+
 - `hue`: Will override layer hue if set.
 - `filterValues`: a dictionary in which each key is a filterable field, and values is an array of all possible values (using OR). ie: `filterValues: { category: [5, 6] }`.
 
@@ -177,10 +180,12 @@ Boolean. Display the associated labels layer, if available.
 
 ### `staticLayer.selectedFeatures`
 
-A filter to apply specific rules per polygon. Polygon filter is defined as:	Object. Defines which features will appear selected on the map. The default appearance of the selected features is defined per GL feature type (fill, circle, etc). It can be overriden.
+A filter to apply specific rules per polygon. Polygon filter is defined as: Object. Defines which features will appear selected on the map. The default appearance of the selected features is defined per GL feature type (fill, circle, etc). It can be overriden.
+
 - `field`: String. A filterable field.
 - `values`: Array. All selected values (logical OR).
 - `style`: [NOT IMPLEMENTED] Object. Defines for each GL paint property (`fill-color`, etc) rules for selected and non selected objects, ie:
+
 ```
 style: {
 'fill-color': [
@@ -220,7 +225,10 @@ String. Mandatory if layer is custom. Can be 'geojson' or 'raster'.
 
 ### `staticLayer.url`
 
-String. Mandatory if custom layer is of subtype 'raster'. Specifies the base URL for raster tiles.
+String.
+
+- Mandatory if custom layer is of subtype 'raster'. Specifies the base URL for raster tiles.
+- Optional if layer is tile layer and it is desired to override the default url
 
 ### `staticLayer.data`
 
@@ -230,22 +238,18 @@ Object. Mandatory if custom layer is of subtype 'geojson'. Specifies GeoJSON dat
 
 Object. If specified, overrides all style info with raw Mapbox GL JSON styles, following the spec defined here: https://github.com/GlobalFishingWatch/map-client/blob/develop/documentation/workspaces.md#gl
 
-
 ## `basemapLayers`
 
 TODO
 
-  basemapLayers: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.string,
-    visible: PropTypes.bool
-  })),
-
+basemapLayers: PropTypes.arrayOf(PropTypes.shape({
+id: PropTypes.string,
+visible: PropTypes.bool
+})),
 
 ## `customLayers`
 
 [NOT IMPLEMENTED] TODO
-
-
 
 ## `hoverPopup`
 
@@ -262,7 +266,6 @@ Number. Mandatory. Latitude for anchor point.
 ### `hoverPopup.longitude`
 
 Number. Mandatory. Longitude for anchor point.
-
 
 ## `clickPopup`
 
@@ -303,7 +306,6 @@ Function. TODO
 ## `onAttributionsChange`
 
 Function. Notify of attributions changes depending on layers toggled [PARTIALLY IMPLEMENTED] Will only fire at start.
-
 
 # Development
 

--- a/src/map/config.js
+++ b/src/map/config.js
@@ -47,3 +47,5 @@ export const STATIC_LAYERS_CARTO_TILES_ENDPOINT =
   'https://carto.globalfishingwatch.org/user/admin/api/v1/map/$LAYERGROUPID/{z}/{x}/{y}.mvt'
 
 export const TRACKS_LAYER_IN_FRONT_OF_GROUP = 'static'
+
+export const TILES_API_URL = 'dot-world-fishing'

--- a/src/map/config.js
+++ b/src/map/config.js
@@ -48,4 +48,4 @@ export const STATIC_LAYERS_CARTO_TILES_ENDPOINT =
 
 export const TRACKS_LAYER_IN_FRONT_OF_GROUP = 'static'
 
-export const TILES_API_URL = 'dot-world-fishing'
+export const TILES_URL_NEEDING_AUTHENTICATION = 'dot-world-fishing'

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -46,6 +46,7 @@ const mapStateToProps = (state, ownProps) => ({
   maxZoom: state.map.viewport.maxZoom,
   minZoom: state.map.viewport.minZoom,
   cursor: state.map.interaction.cursor,
+  token: state.map.module.token,
   mapStyle: getMapStyle(state),
   interactiveLayerIds: getInteractiveLayerIds(state),
 })

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -125,6 +125,16 @@ class Map extends React.Component {
     return cursor
   }
 
+  transformRequest = (url, resourceType) => {
+    const { token } = this.props
+    if (token !== null && resourceType === 'Tile' && url.match('dot-world-fishing')) {
+      return {
+        url: url,
+        headers: { Authorization: 'Bearer ' + token },
+      }
+    }
+  }
+
   render() {
     const {
       viewport,
@@ -153,6 +163,7 @@ class Map extends React.Component {
       >
         <MapGL
           ref={this.getRef}
+          transformRequest={this.transformRequest}
           onTransitionEnd={transitionEnd}
           onHover={this.onHover}
           onClick={this.onClick}
@@ -192,6 +203,7 @@ class Map extends React.Component {
 }
 
 Map.propTypes = {
+  token: PropTypes.string,
   viewport: PropTypes.object.isRequired,
   mapStyle: PropTypes.object.isRequired,
   clickPopup: PropTypes.object,
@@ -208,6 +220,7 @@ Map.propTypes = {
 }
 
 Map.defaultProps = {
+  token: null,
   clickPopup: null,
   hoverPopup: null,
   mapHover: () => {},

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -23,6 +23,14 @@ const PopupWrapper = (props) => {
   )
 }
 
+PopupWrapper.propTypes = {
+  latitude: PropTypes.string.isRequired,
+  longitude: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  closeButton: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+}
+
 class Map extends React.Component {
   constructor(props) {
     super(props)
@@ -103,6 +111,20 @@ class Map extends React.Component {
     this.onMapInteraction(event, 'click')
   }
 
+  getRef = (ref) => {
+    if (ref !== null) {
+      this.glMap = ref.getMap()
+    }
+  }
+
+  getCursor = ({ isDragging }) => {
+    const { cursor } = this.props
+    if (cursor === null) {
+      return isDragging ? 'grabbing' : 'grab'
+    }
+    return cursor
+  }
+
   render() {
     const {
       viewport,
@@ -113,7 +135,6 @@ class Map extends React.Component {
       onClosePopup,
       clickPopup,
       hoverPopup,
-      cursor,
       interactiveLayerIds,
     } = this.props
     return (
@@ -131,20 +152,11 @@ class Map extends React.Component {
         }}
       >
         <MapGL
-          ref={(ref) => {
-            if (ref !== null) {
-              this.glMap = ref.getMap()
-            }
-          }}
+          ref={this.getRef}
           onTransitionEnd={transitionEnd}
           onHover={this.onHover}
           onClick={this.onClick}
-          getCursor={({ isDragging }) => {
-            if (cursor === null) {
-              return isDragging ? 'grabbing' : 'grab'
-            }
-            return cursor
-          }}
+          getCursor={this.getCursor}
           mapStyle={mapStyle}
           {...viewport}
           maxZoom={maxZoom}
@@ -152,7 +164,7 @@ class Map extends React.Component {
           onViewportChange={this.onViewportChange}
           interactiveLayerIds={interactiveLayerIds}
         >
-          <ActivityLayers loadTemporalExtent={this.props.loadTemporalExtent} />
+          <ActivityLayers />
           {clickPopup !== undefined && clickPopup !== null && (
             <PopupWrapper
               latitude={clickPopup.latitude}
@@ -180,19 +192,30 @@ class Map extends React.Component {
 }
 
 Map.propTypes = {
-  viewport: PropTypes.object,
-  mapStyle: PropTypes.object,
+  viewport: PropTypes.object.isRequired,
+  mapStyle: PropTypes.object.isRequired,
   clickPopup: PropTypes.object,
   hoverPopup: PropTypes.object,
-  maxZoom: PropTypes.number,
-  minZoom: PropTypes.number,
-  setViewport: PropTypes.func,
+  maxZoom: PropTypes.number.isRequired,
+  minZoom: PropTypes.number.isRequired,
+  setViewport: PropTypes.func.isRequired,
   mapHover: PropTypes.func,
   mapClick: PropTypes.func,
   onClosePopup: PropTypes.func,
   transitionEnd: PropTypes.func,
   cursor: PropTypes.string,
   interactiveLayerIds: PropTypes.arrayOf(PropTypes.string),
+}
+
+Map.defaultProps = {
+  clickPopup: null,
+  hoverPopup: null,
+  mapHover: () => {},
+  mapClick: () => {},
+  onClosePopup: () => {},
+  transitionEnd: () => {},
+  cursor: null,
+  interactiveLayerIds: null,
 }
 
 export default Map

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MapGL, { Popup } from 'react-map-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import { TILES_API_URL } from '../config'
 import ActivityLayers from '../activity/ActivityLayers.container.js'
 import styles from './map.css'
 
@@ -127,7 +128,7 @@ class Map extends React.Component {
 
   transformRequest = (url, resourceType) => {
     const { token } = this.props
-    if (token !== null && resourceType === 'Tile' && url.match('dot-world-fishing')) {
+    if (token !== null && resourceType === 'Tile' && url.match(TILES_API_URL)) {
       return {
         url: url,
         headers: { Authorization: 'Bearer ' + token },

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import MapGL, { Popup } from 'react-map-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import { TILES_API_URL } from '../config'
+import { TILES_URL_NEEDING_AUTHENTICATION } from '../config'
 import ActivityLayers from '../activity/ActivityLayers.container.js'
 import styles from './map.css'
 
@@ -128,7 +128,7 @@ class Map extends React.Component {
 
   transformRequest = (url, resourceType) => {
     const { token } = this.props
-    if (token !== null && resourceType === 'Tile' && url.match(TILES_API_URL)) {
+    if (token !== null && resourceType === 'Tile' && url.match(TILES_URL_NEEDING_AUTHENTICATION)) {
       return {
         url: url,
         headers: { Authorization: 'Bearer ' + token },

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -1,5 +1,6 @@
 import { fromJS } from 'immutable'
 import { hexToRgb } from '../utils/map-colors'
+import uniq from 'lodash/uniq'
 import { STATIC_LAYERS_CARTO_ENDPOINT, STATIC_LAYERS_CARTO_TILES_ENDPOINT } from '../config'
 import { CUSTOM_LAYERS_SUBTYPES, GL_TRANSPARENT } from '../constants'
 import GL_STYLE from './gl-styles/style.json'
@@ -404,8 +405,17 @@ export const commitStyleUpdates = (staticLayers, basemapLayers) => (dispatch, ge
   // update source when needed
   staticLayers.forEach((refLayer) => {
     const sourceId = refLayer.id
-    if (refLayer.data !== undefined && currentGLSources[sourceId] !== undefined) {
-      style = style.setIn(['sources', sourceId, 'data'], fromJS(refLayer.data))
+    if (currentGLSources[sourceId] !== undefined) {
+      if (refLayer.data !== undefined) {
+        style = style.setIn(['sources', sourceId, 'data'], fromJS(refLayer.data))
+      }
+      if (refLayer.url !== undefined) {
+        const { tiles } = currentGLSources[sourceId]
+        // Using default tiles url as a fallback
+        const newTiles =
+          tiles !== undefined && tiles.length > 0 ? uniq([refLayer.url, ...tiles]) : [refLayer.url]
+        style = style.setIn(['sources', sourceId, 'tiles'], fromJS(newTiles))
+      }
     }
   })
 

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -77,6 +77,8 @@ const updateViewportFromIncomingProps = (incomingViewport) => {
 class MapModule extends React.Component {
   state = {
     initialized: false,
+    error: null,
+    errorInfo: null,
   }
 
   componentDidCatch(error, errorInfo) {
@@ -96,7 +98,7 @@ class MapModule extends React.Component {
     }
 
     // TODO
-    if (this.props.glyphsPath !== undefined) {
+    if (this.props.glyphsPath !== null) {
       store.dispatch(
         initStyle({
           glyphsPath: this.props.glyphsPath,
@@ -129,8 +131,8 @@ class MapModule extends React.Component {
     }
 
     if (
-      (this.props.basemapLayers !== undefined && this.props.basemapLayers.length) ||
-      (this.props.staticLayers !== undefined && this.props.staticLayers.length)
+      (this.props.basemapLayers !== null && this.props.basemapLayers.length) ||
+      (this.props.staticLayers !== null && this.props.staticLayers.length)
     ) {
       store.dispatch(
         commitStyleUpdates(this.props.staticLayers || [], this.props.basemapLayers || [])
@@ -143,7 +145,7 @@ class MapModule extends React.Component {
 
     // Now trigger async actions
 
-    if (this.props.temporalExtent !== undefined && this.props.temporalExtent.length) {
+    if (this.props.temporalExtent !== null && this.props.temporalExtent.length) {
       throttleApplyTemporalExtent(this.props.temporalExtent)
     }
 
@@ -166,8 +168,8 @@ class MapModule extends React.Component {
 
     // basemap / static layers
     if (
-      (this.props.basemapLayers !== undefined && this.props.basemapLayers.length) ||
-      (this.props.staticLayers !== undefined && this.props.staticLayers.length)
+      (this.props.basemapLayers !== null && this.props.basemapLayers.length) ||
+      (this.props.staticLayers !== null && this.props.staticLayers.length)
     ) {
       store.dispatch(
         commitStyleUpdates(this.props.staticLayers || [], this.props.basemapLayers || [])
@@ -175,9 +177,9 @@ class MapModule extends React.Component {
     }
 
     // loadTemporalExtent
-    if (this.props.loadTemporalExtent !== undefined && this.props.loadTemporalExtent.length) {
+    if (this.props.loadTemporalExtent !== null && this.props.loadTemporalExtent.length) {
       if (
-        prevProps.loadTemporalExtent === undefined ||
+        prevProps.loadTemporalExtent === null ||
         !prevProps.loadTemporalExtent.length ||
         this.props.loadTemporalExtent[0].getTime() !== prevProps.loadTemporalExtent[0].getTime() ||
         this.props.loadTemporalExtent[1].getTime() !== prevProps.loadTemporalExtent[1].getTime()
@@ -186,9 +188,9 @@ class MapModule extends React.Component {
       }
     }
     // temporalExtent
-    if (this.props.temporalExtent !== undefined && this.props.temporalExtent.length) {
+    if (this.props.temporalExtent !== null && this.props.temporalExtent.length) {
       if (
-        prevProps.temporalExtent === undefined ||
+        prevProps.temporalExtent === null ||
         !prevProps.temporalExtent.length ||
         this.props.temporalExtent[0].getTime() !== prevProps.temporalExtent[0].getTime() ||
         this.props.temporalExtent[1].getTime() !== prevProps.temporalExtent[1].getTime()
@@ -241,7 +243,7 @@ class MapModule extends React.Component {
     }
   }
   render() {
-    if (this.state.error !== undefined) {
+    if (this.state.error !== null) {
       console.log(this.state.error)
       return (
         <div>
@@ -263,7 +265,7 @@ class MapModule extends React.Component {
 
 MapModule.propTypes = {
   token: PropTypes.string,
-  viewport: PropTypes.shape(viewportTypes),
+  viewport: PropTypes.shape(viewportTypes).isRequired,
   tracks: PropTypes.arrayOf(PropTypes.exact(trackTypes)),
   heatmapLayers: PropTypes.arrayOf(PropTypes.shape(heatmapLayerTypes)),
   temporalExtent: PropTypes.arrayOf(PropTypes.instanceOf(Date)),
@@ -285,8 +287,24 @@ MapModule.propTypes = {
 }
 
 MapModule.defaultProps = {
+  token: null,
+  glyphsPath: null,
   highlightTemporalExtent: null,
   tracks: null,
+  hoverPopup: null,
+  clickPopup: null,
+  heatmapLayers: null,
+  temporalExtent: null,
+  loadTemporalExtent: null,
+  basemapLayers: null,
+  staticLayers: null,
+  onViewportChange: () => {},
+  onLoadStart: () => {},
+  onLoadComplete: () => {},
+  onClick: () => {},
+  onHover: () => {},
+  onAttributionsChange: () => {},
+  onClosePopup: () => {},
 }
 
 export default MapModule

--- a/src/timebar/charts/vessel-events.js
+++ b/src/timebar/charts/vessel-events.js
@@ -283,7 +283,7 @@ class VesselEvents extends Component {
                 onClick={() => onEventClick(props.event)}
               >
                 <rect
-                  class={`vessel-event -${props.event.type}`}
+                  className={`vessel-event -${props.event.type}`}
                   x={props.style.x1}
                   y={-props.height / 2}
                   width={props.style.width}
@@ -311,6 +311,8 @@ VesselEvents.propTypes = {
       type: PropTypes.string,
     })
   ).isRequired,
+  outerStart: PropTypes.string.isRequired,
+  outerEnd: PropTypes.string.isRequired,
   selectedEventID: PropTypes.string,
   highlightedEventIDs: PropTypes.arrayOf(PropTypes.string),
   outerScale: PropTypes.func.isRequired,
@@ -327,6 +329,7 @@ VesselEvents.defaultProps = {
   highlightedEventIDs: null,
   onEventHighlighted: () => {},
   onEventClick: () => {},
+  tooltipContainer: null,
 }
 
 export default VesselEvents


### PR DESCRIPTION
Two features in one PR:
- [x] Allows customising URL tiles for static layers using new `url` property
- [x] Send token in custom mapbox tiles

As the `defaultProps` eslint rule was added it also includes default props validation.

![image](https://user-images.githubusercontent.com/10500650/55793857-29a0ba80-5ac4-11e9-8b49-34c451c229a7.png)
