### PR TITLE
Proper map code splitting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,9 @@
 {
-  "extends": ["prettier", "react-app"],
-  "plugins": ["prettier"],
+  "extends": ["react-app", "plugin:prettier/recommended"],
+  "plugins": ["react"],
   "rules": {
     "prettier/prettier": "error",
     "react/prop-types": "error",
     "react/require-default-props": "error"
-  },
-  "globals": {}
+  }
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,7 +2,6 @@
   "*.css": ["prettier --write", "stylelint --fix", "git add"],
   "*.scss": ["prettier --write", "stylelint --syntax=scss --fix", "git add"],
   "*.{js,jsx}": [
-    "prettier --write",
     "eslint --fix",
     "git add"
   ],

--- a/src/map/basemaps/index.js
+++ b/src/map/basemaps/index.js
@@ -1,0 +1,5 @@
+import GL_STYLE from '../glmap/gl-styles/style.json'
+
+const AVAILABLE_BASEMAPS = GL_STYLE.metadata['gfw:basemap-layers']
+
+export default AVAILABLE_BASEMAPS

--- a/src/map/glmap/viewport.reducer.js
+++ b/src/map/glmap/viewport.reducer.js
@@ -1,4 +1,4 @@
-import { FlyToInterpolator } from 'react-map-gl'
+import FlyToInterpolator from 'react-map-gl/dist/es5/utils/transition/viewport-fly-to-interpolator'
 import { easeCubic } from 'd3-ease'
 import { MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL } from '../config'
 import { TRANSITION_TYPE } from '../constants'

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,1 +1,3 @@
-export { default, targetMapVessel, AVAILABLE_BASEMAPS } from './map'
+export { default } from './map'
+export { targetMapVessel } from './store'
+export { default as AVAILABLE_BASEMAPS } from './basemaps'

--- a/src/map/store/index.js
+++ b/src/map/store/index.js
@@ -1,0 +1,31 @@
+import { compose, createStore, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
+
+import { fitToBounds } from '../glmap/viewport.actions'
+
+let composeEnhancers = compose
+if (
+  (process.env.MAP_REDUX_REMOTE_DEBUG || process.env.REACT_APP_MAP_REDUX_REMOTE_DEBUG) &&
+  process.env.NODE_ENV === 'development'
+) {
+  const composeWithDevTools = require('remote-redux-devtools').composeWithDevTools
+  composeEnhancers = composeWithDevTools({
+    name: 'Map module',
+    realtime: true,
+    hostname: 'localhost',
+    port: 8000,
+    maxAge: 30,
+    stateSanitizer: (state) => ({ ...state, map: { ...state.map, heatmap: 'NOT_SERIALIZED' } }),
+  })
+}
+
+const store = createStore(() => {}, {}, composeEnhancers(applyMiddleware(thunk)))
+
+export const targetMapVessel = (id) => {
+  const track = store.getState().map.tracks.data.find((t) => t.id === id.toString())
+  store.dispatch(fitToBounds(track.geoBounds))
+
+  return track.timelineBounds
+}
+
+export default store

--- a/src/map/store/reducers.js
+++ b/src/map/store/reducers.js
@@ -1,0 +1,21 @@
+import { combineReducers } from 'redux'
+
+import ModuleReducer from '../module/module.reducer'
+import TracksReducer from '../tracks/tracks.reducer'
+import HeatmapReducer from '../heatmap/heatmap.reducer'
+import HeatmapTilesReducer from '../heatmap/heatmapTiles.reducer'
+import ViewportReducer from '../glmap/viewport.reducer'
+import StyleReducer from '../glmap/style.reducer'
+import InteractionReducer from '../glmap/interaction.reducer'
+
+const mapReducer = combineReducers({
+  module: ModuleReducer,
+  tracks: TracksReducer,
+  heatmap: HeatmapReducer,
+  heatmapTiles: HeatmapTilesReducer,
+  style: StyleReducer,
+  viewport: ViewportReducer,
+  interaction: InteractionReducer,
+})
+
+export default mapReducer

--- a/src/map/tracks/tracks.actions.js
+++ b/src/map/tracks/tracks.actions.js
@@ -1,5 +1,5 @@
 import tbbox from '@turf/bbox'
-import { targetMapVessel } from '../map'
+import { targetMapVessel } from '../store'
 
 import {
   getTilePromises,


### PR DESCRIPTION
Reviewing the map-client project I realized the map was exporting everything (mapbox-gl, pixi.js...) from `index.js` and there were use cases when we don't need it as for example to import the [AVAILABLE_BASEMAPS](https://github.com/GlobalFishingWatch/map-components/compare/map-code-spitting?expand=1#diff-f70efa84e588921f5bed36b357761ffeR3) or `targetMapVessel`. To achieve that it uses https://redux.js.org/recipes/code-splitting#using-replacereducer to make the imports much lighter.

Basically now we can [import the map dynamically](https://github.com/GlobalFishingWatch/map-client/commit/d889ad6c7ec4fa8d3c4f80b95e9e3ecdfc374a8b) which makes the first load paint more than 3 seconds faster.
Before:
![image](https://user-images.githubusercontent.com/10500650/55950678-bfb81a80-5c55-11e9-8813-f6cdbc9de758.png)

Now:
![image](https://user-images.githubusercontent.com/10500650/55950686-c5156500-5c55-11e9-8067-44c5dafc205e.png)

Also makes the commits hook faster as don't run prettier twice.