### PR TITLE
Country flag emoji fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@turf/area": "^6.0.1",
     "@turf/bbox": "^6.0.1",
     "classnames": "^2.2.6",
-    "countryflag": "^2.3.0",
+    "countryflag": "^2.3.1",
     "d3-ease": "^1.0.5",
     "d3-geo": "^1.11.3",
     "d3-scale": "^2.2.2",

--- a/src/countryflag/countryflag.js
+++ b/src/countryflag/countryflag.js
@@ -4,7 +4,9 @@ import countryflag from 'countryflag'
 
 class CountryFlag extends Component {
   render() {
-    const { iso, iso2, svg, size } = this.props
+    // iso2 is deprecated, ignoring prop-types
+    // eslint-disable-next-line react/prop-types
+    const { iso, iso2, svg, size, margin } = this.props
     if (!iso && !iso2) {
       console.error(' Country flag iso (iso 3) or iso2 code is required')
       return null
@@ -15,7 +17,7 @@ class CountryFlag extends Component {
     const flag = countryflag(iso || iso2)
     return svg === true || flag.emoji === null ? (
       <img
-        style={{ height: size, marginRight: '0.2em', marginLeft: '0.1em' }}
+        style={{ height: size, marginRight: margin.right, marginLeft: margin.left }}
         alt={flag.name}
         src={flag.svg}
       />
@@ -31,11 +33,19 @@ CountryFlag.propTypes = {
   iso: PropTypes.string.isRequired,
   svg: PropTypes.bool,
   size: PropTypes.string,
+  margin: PropTypes.shape({
+    left: PropTypes.string,
+    righ: PropTypes.string,
+  }),
 }
 
 CountryFlag.defaultProps = {
   svg: false,
   size: '1em',
+  margin: {
+    left: '0.1em',
+    right: '0.2em',
+  },
 }
 
 export default CountryFlag

--- a/yarn.lock
+++ b/yarn.lock
@@ -4783,10 +4783,10 @@ cosmiconfig@^5.2.0:
     js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
-countryflag@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/countryflag/-/countryflag-2.3.0.tgz#c8372bf26e3d4276e1fdc5304679c4862ffedad8"
-  integrity sha512-8DCgfafPxWfb3jWOOgNNKIZFxUA9MuaTjIhsHPhm0U02kseu+h/S4s8NpAY+Ce2aCVUH5VvrhpynuvvAPcVpxA==
+countryflag@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/countryflag/-/countryflag-2.3.1.tgz#e2fe3efdd919284dbad9d9361b107791f28231cc"
+  integrity sha512-K1UrSI0baB/lxFt+WgB73eIdWFXVmD902uAOCK/n03ezgoe9RSgHBpGyEEdYMXw9r/YB0rQqPmSKck3/YtLDSA==
   dependencies:
     if-emoji "^0.1.0"
     world-countries "^2.1.0"


### PR DESCRIPTION
The emojis issue comes from the `countryflag` library as always return an emoji even when it doesn't have support.

Package.json pending to update with countryflag version 2.3.1 once published.