### PR TITLE
Fix mapbox missing css warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "d3-shape": "^1.3.4",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.11",
+    "mapbox-gl": "^0.53.1",
     "memoize-one": "^5.0.0",
     "pbf": "^3.2.0",
     "prop-types": "^15.6.2",
@@ -51,6 +52,7 @@
   "peerDependencies": {
     "dayjs": "^1.7.7",
     "pixi.js": "^4.7.1",
+    "mapbox-gl": "^0.53.1",
     "react": "^15.6.1 || ^16.0.0",
     "react-dom": "^15.6.1 || ^16.0.0",
     "react-map-gl": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10420,7 +10420,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@~0.53.0:
+mapbox-gl@^0.53.1, mapbox-gl@~0.53.0:
   version "0.53.1"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.53.1.tgz#08a956d8da54b04bc7f29ab1319bddb9c97ddedf"
   integrity sha512-dTtW/qlkUowKGlqOhE8fqII2Tj4lcokvlZwUDLnkjy4uQ9zMFnVBULGeSzzTVkj9HtQZ3Zbey10/jmoVPV9t5w==


### PR DESCRIPTION
Fix warning on missing mapbox-gl styles, closes: https://github.com/GlobalFishingWatch/map-components/issues/23