### PR TITLE
Allow to input timebar days and years with keyboard

### DIFF
--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -1,3 +1,7 @@
+html {
+  font-size: 10px;
+}
+
 body {
   margin: 0;
   padding: 0;

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -9,10 +9,7 @@ import { ReactComponent as IconArrowDown } from '../icons/arrowDown.svg'
 class DateSelector extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      value: props.value,
-      error: false,
-    }
+    this.state = { value: props.value }
     this.months = Array.from(Array(12).keys()).map((i) => ({
       value: i,
       label: dayjs()
@@ -24,23 +21,6 @@ class DateSelector extends Component {
   componentWillReceiveProps(nextProps) {
     if (this.props.value !== nextProps.value) {
       this.setState({ value: nextProps.value })
-    }
-  }
-
-  validate(value) {
-    const { unit } = this.props
-    const isNumber = typeof value === 'number'
-    if (!isNumber) return false
-
-    switch (unit) {
-      case 'date':
-        return value > 0 && value <= 31
-      case 'month':
-        return value >= 0 && value < 12
-      case 'year':
-        return value > 2012 && value <= new Date().getFullYear()
-      default:
-        return false
     }
   }
 
@@ -60,21 +40,13 @@ class DateSelector extends Component {
   }
 
   setValue = (value) => {
-    const isValid = this.validate(value)
-    this.setState({ value, error: !isValid }, () => {
-      if (isValid) {
-        this.debouncedChange(value)
-      }
-    })
-  }
-
-  debouncedChange = (value) => {
+    this.setState({ value })
     this.props.onChange(value, this.props.unit)
   }
 
   render() {
-    const { value, error } = this.state
-    const { unit, label, canIncrement, canDecrement } = this.props
+    const { value } = this.state
+    const { unit, label, canIncrement, canDecrement, valid } = this.props
     return (
       <div className={styles.DateSelector}>
         <button
@@ -86,7 +58,12 @@ class DateSelector extends Component {
           <IconArrowUp />
         </button>
         {label !== '' && (
-          <label className={cx(styles.valueInput, styles.labelInput)} htmlFor={label + unit}>
+          <label
+            className={cx(styles.valueInput, styles.labelInput, {
+              [styles.valueInputError]: !valid,
+            })}
+            htmlFor={label + unit}
+          >
             {label}
           </label>
         )}
@@ -95,7 +72,7 @@ class DateSelector extends Component {
             type="text"
             name={label + unit}
             value={value}
-            className={cx(styles.valueInput, { [styles.valueInputError]: error })}
+            className={cx(styles.valueInput, { [styles.valueInputError]: !valid })}
             onChange={this.onInputChange}
           />
         )}
@@ -107,7 +84,9 @@ class DateSelector extends Component {
             onChange={this.onInputChange}
           >
             {this.months.map((m) => (
-              <option value={m.value}>{m.label}</option>
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
             ))}
           </select>
         )}
@@ -125,6 +104,7 @@ class DateSelector extends Component {
 }
 
 DateSelector.propTypes = {
+  valid: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   unit: PropTypes.oneOf(['date', 'month', 'year']).isRequired,
   label: PropTypes.string,
@@ -134,6 +114,7 @@ DateSelector.propTypes = {
 }
 
 DateSelector.defaultProps = {
+  valid: true,
   label: '',
 }
 

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import dayjs from 'dayjs'
 import styles from './date-selector.module.css'
 import { ReactComponent as IconArrowUp } from '../icons/arrowUp.svg'
 import { ReactComponent as IconArrowDown } from '../icons/arrowDown.svg'
@@ -12,6 +13,12 @@ class DateSelector extends Component {
       value: props.value,
       error: false,
     }
+    this.months = Array.from(Array(12).keys()).map((i) => ({
+      value: i,
+      label: dayjs()
+        .month(i)
+        .format('MMM'),
+    }))
   }
 
   componentWillReceiveProps(nextProps) {
@@ -25,7 +32,6 @@ class DateSelector extends Component {
     const isNumber = typeof value === 'number'
     if (!isNumber) return false
 
-    // TODO: validate days / months / years
     switch (unit) {
       case 'date':
         return value > 0 && value <= 31
@@ -50,6 +56,10 @@ class DateSelector extends Component {
 
   onInputChange = (event) => {
     const value = event.target.value && parseInt(event.target.value)
+    this.setValue(value)
+  }
+
+  setValue = (value) => {
     const isValid = this.validate(value)
     this.setState({ value, error: !isValid }, () => {
       if (isValid) {
@@ -90,9 +100,15 @@ class DateSelector extends Component {
           />
         )}
         {unit === 'month' && (
-          <select className={styles.selectInput} name={label + unit}>
-            <option>Enero</option>
-            <option>Febrero</option>
+          <select
+            value={value}
+            name={label + unit}
+            className={styles.selectInput}
+            onChange={this.onInputChange}
+          >
+            {this.months.map((m) => (
+              <option value={m.value}>{m.label}</option>
+            ))}
           </select>
         )}
         <button

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -1,32 +1,97 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import styles from './date-selector.module.css'
 import { ReactComponent as IconArrowUp } from '../icons/arrowUp.svg'
 import { ReactComponent as IconArrowDown } from '../icons/arrowDown.svg'
 
 class DateSelector extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: props.value,
+      error: false,
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.value !== nextProps.value) {
+      this.setState({ value: nextProps.value })
+    }
+  }
+
+  validate(value) {
+    const { unit } = this.props
+    const isNumber = typeof value === 'number'
+    if (!isNumber) return false
+
+    // TODO: validate days / months / years
+    switch (unit) {
+      case 'date':
+        return value > 0 && value < 31
+      case 'month':
+        return value >= 0 && value < 12
+      case 'year':
+        return value > 2012 && value < new Date().getFullYear()
+      default:
+        return false
+    }
+  }
+
+  onIncrementClick = () => {
+    const { value, unit } = this.props
+    this.props.onChange(value + 1, unit)
+  }
+
+  onDecrementClick = () => {
+    const { value, unit } = this.props
+    this.props.onChange(value - 1, unit)
+  }
+
+  onInputChange = (event) => {
+    const value = event.target.value && parseInt(event.target.value)
+    const isValid = this.validate(value)
+    this.setState({ value, error: !isValid }, () => {
+      if (isValid) {
+        this.debouncedChange(value)
+      }
+    })
+  }
+
+  debouncedChange = (value) => {
+    this.props.onChange(value, this.props.unit)
+  }
+
   render() {
-    const { onChange, value, canIncrement, canDecrement } = this.props
+    const { value, error } = this.state
+    const { unit, label, canIncrement, canDecrement } = this.props
     return (
       <div className={styles.DateSelector}>
         <button
           type="button"
           className={styles.arrowButton}
           disabled={!canIncrement}
-          onClick={() => {
-            onChange(+1)
-          }}
+          onClick={this.onIncrementClick}
         >
           <IconArrowUp />
         </button>
-        <span className={styles.value}>{value}</span>
+        {label !== '' && (
+          <label className={cx(styles.valueInput, styles.labelInput)} htmlFor={label + unit}>
+            {label}
+          </label>
+        )}
+        <input
+          type="text"
+          name={label + unit}
+          value={value}
+          className={cx(styles.valueInput, { [styles.valueInputError]: error })}
+          onChange={this.onInputChange}
+        />
         <button
           type="button"
           className={styles.arrowButton}
           disabled={!canDecrement}
-          onClick={() => {
-            onChange(-1)
-          }}
+          onClick={this.onDecrementClick}
         >
           <IconArrowDown />
         </button>
@@ -37,9 +102,15 @@ class DateSelector extends Component {
 
 DateSelector.propTypes = {
   onChange: PropTypes.func.isRequired,
+  unit: PropTypes.oneOf(['date', 'month', 'year']).isRequired,
+  label: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   canIncrement: PropTypes.bool.isRequired,
   canDecrement: PropTypes.bool.isRequired,
+}
+
+DateSelector.defaultProps = {
+  label: '',
 }
 
 export default DateSelector

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -26,12 +26,12 @@ class DateSelector extends Component {
 
   onIncrementClick = () => {
     const { value, unit } = this.props
-    this.props.onChange(value + 1, unit)
+    this.props.onChange(value + 1, unit, true)
   }
 
   onDecrementClick = () => {
     const { value, unit } = this.props
-    this.props.onChange(value - 1, unit)
+    this.props.onChange(value - 1, unit, true)
   }
 
   onInputChange = (event) => {

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -28,11 +28,11 @@ class DateSelector extends Component {
     // TODO: validate days / months / years
     switch (unit) {
       case 'date':
-        return value > 0 && value < 31
+        return value > 0 && value <= 31
       case 'month':
         return value >= 0 && value < 12
       case 'year':
-        return value > 2012 && value < new Date().getFullYear()
+        return value > 2012 && value <= new Date().getFullYear()
       default:
         return false
     }
@@ -80,13 +80,21 @@ class DateSelector extends Component {
             {label}
           </label>
         )}
-        <input
-          type="text"
-          name={label + unit}
-          value={value}
-          className={cx(styles.valueInput, { [styles.valueInputError]: error })}
-          onChange={this.onInputChange}
-        />
+        {unit !== 'month' && (
+          <input
+            type="text"
+            name={label + unit}
+            value={value}
+            className={cx(styles.valueInput, { [styles.valueInputError]: error })}
+            onChange={this.onInputChange}
+          />
+        )}
+        {unit === 'month' && (
+          <select className={styles.selectInput} name={label + unit}>
+            <option>Enero</option>
+            <option>Febrero</option>
+          </select>
+        )}
         <button
           type="button"
           className={styles.arrowButton}

--- a/src/timebar/components/date-selector.module.css
+++ b/src/timebar/components/date-selector.module.css
@@ -4,6 +4,7 @@
   flex-direction: column;
   width: 4.2rem;
   margin-right: 1rem;
+  position: relative;
 }
 
 .arrowButton {
@@ -31,12 +32,27 @@
   outline: none;
 }
 
-.value {
-  display: flex;
-  height: 3.4rem;
-  align-items: center;
-  justify-content: center;
+.valueInput {
+  height: 2.7rem;
+  padding: 0;
+  text-align: center;
   background: var(--timebar-secondary-background-color);
   color: var(--timebar-light-blue);
   text-transform: uppercase;
+  border: 1px solid transparent;
+  outline: none;
+}
+
+.labelInput {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  height: auto;
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.valueInputError {
+  border-color: red;
 }

--- a/src/timebar/components/date-selector.module.css
+++ b/src/timebar/components/date-selector.module.css
@@ -41,16 +41,21 @@
   text-transform: uppercase;
   border: 1px solid transparent;
   outline: none;
+  font-size: var(--timebar-font-size);
+  font-weight: 400;
+  line-height: 2.7rem;
 }
 
-.labelInput {
+.selectInput {
   position: absolute;
-  left: 50%;
+  left: 0;
+  width: 100%;
+  height: 2.7rem;
+  opacity: 0;
+  cursor: pointer;
   top: 50%;
-  transform: translate(-50%, -50%);
-  height: auto;
-  font-size: 11px;
-  font-weight: 400;
+  transform: translateY(-50%);
+  font-size: var(--timebar-font-size);
 }
 
 .valueInputError {

--- a/src/timebar/components/timerange-selector.js
+++ b/src/timebar/components/timerange-selector.js
@@ -40,9 +40,32 @@ class TimeRangeSelector extends Component {
     onSubmit(newStart, newEnd)
   }
 
-  setUnit(which, allBounds, unit, offset) {
+  onStartChange = (value, unit) => {
+    this.setUnit('start', unit, value)
+  }
+
+  onEndChange = (value, unit) => {
+    this.setUnit('end', unit, value)
+  }
+
+  setUnit(which, unit, value) {
     const prevDate = this.state[which]
-    const newDate = dayjs(prevDate).add(offset, unit)
+    // const newDate = dayjs(prevDate).add(offset, unit)
+    const newDate = dayjs(prevDate).set(unit, value)
+
+    const { absoluteStart, absoluteEnd } = this.props
+    const { start, end } = this.state
+
+    const allBounds = {
+      start: {
+        min: getTime(absoluteStart),
+        max: getTime(end) - ONE_DAY_MS,
+      },
+      end: {
+        min: getTime(start) + ONE_DAY_MS,
+        max: getTime(absoluteEnd),
+      },
+    }
 
     const bounds = allBounds[which]
     let newDateMs = newDate.toDate().getTime()
@@ -74,21 +97,9 @@ class TimeRangeSelector extends Component {
       endCanIncrement,
       endCanDecrement,
     } = this.state
-    const { absoluteStart, absoluteEnd } = this.props
 
     if (start === undefined) {
       return null
-    }
-
-    const bounds = {
-      start: {
-        min: getTime(absoluteStart),
-        max: getTime(end) - ONE_DAY_MS,
-      },
-      end: {
-        min: getTime(start) + ONE_DAY_MS,
-        max: getTime(absoluteEnd),
-      },
     }
     const mStart = dayjs(start)
     const mEnd = dayjs(end)
@@ -101,54 +112,50 @@ class TimeRangeSelector extends Component {
           <div className={styles.selectorGroup}>
             <span className={styles.selectorLabel}>START</span>
             <DateSelector
+              unit="date"
               canIncrement={startCanIncrement}
               canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'day', offset)
-              }}
+              onChange={this.onStartChange}
               value={mStart.date()}
             />
             <DateSelector
+              unit="month"
               canIncrement={startCanIncrement}
               canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'month', offset)
-              }}
-              value={mStart.format('MMM')}
+              onChange={this.onStartChange}
+              label={mStart.format('MMM')}
+              value={mStart.month()}
             />
             <DateSelector
+              unit="year"
               canIncrement={startCanIncrement}
               canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'year', offset)
-              }}
+              onChange={this.onStartChange}
               value={mStart.year()}
             />
           </div>
           <div className={styles.selectorGroup}>
             <span className={styles.selectorLabel}>END</span>
             <DateSelector
+              unit="date"
               canIncrement={endCanIncrement}
               canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'day', offset)
-              }}
+              onChange={this.onEndChange}
               value={mEnd.date()}
             />
             <DateSelector
+              unit="month"
               canIncrement={endCanIncrement}
               canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'month', offset)
-              }}
-              value={mEnd.format('MMM')}
+              onChange={this.onEndChange}
+              label={mEnd.format('MMM')}
+              value={mEnd.month()}
             />
             <DateSelector
+              unit="year"
               canIncrement={endCanIncrement}
               canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'year', offset)
-              }}
+              onChange={this.onEndChange}
               value={mEnd.year()}
             />
           </div>
@@ -178,6 +185,7 @@ class TimeRangeSelector extends Component {
 
 TimeRangeSelector.propTypes = {
   onSubmit: PropTypes.func.isRequired,
+  onDiscard: PropTypes.func.isRequired,
   start: PropTypes.string.isRequired,
   end: PropTypes.string.isRequired,
   absoluteStart: PropTypes.string.isRequired,

--- a/src/timebar/components/timerange-selector.module.css
+++ b/src/timebar/components/timerange-selector.module.css
@@ -58,18 +58,19 @@ h2 {
   cursor: not-allowed;
   width: 15rem;
   height: 3.6rem;
-  background: var(--timebar-cta-btn-color);
   color: var(--timebar-white);
   font-size: var(--timebar-font-size);
   transition: var(--timebar-hover-transition);
+  background-color: var(--timebar-ui-btn-color-hover);
 }
 
 .cta:not([disabled]) {
   cursor: pointer;
+  background: var(--timebar-cta-btn-color);
 }
 
-.cta:hover,
-.cta:focus {
+.cta:not([disabled]):hover,
+.cta:not([disabled]):focus {
   background: var(--timebar-cta-btn-hover);
   outline: none;
 }

--- a/src/timebar/components/timerange-selector.module.css
+++ b/src/timebar/components/timerange-selector.module.css
@@ -55,13 +55,17 @@ h2 {
   border: none;
   padding: 0;
   border-radius: 0;
-  cursor: pointer;
+  cursor: not-allowed;
   width: 15rem;
   height: 3.6rem;
   background: var(--timebar-cta-btn-color);
   color: var(--timebar-white);
   font-size: var(--timebar-font-size);
   transition: var(--timebar-hover-transition);
+}
+
+.cta:not([disabled]) {
+  cursor: pointer;
 }
 
 .cta:hover,

--- a/src/timebar/timebar.js
+++ b/src/timebar/timebar.js
@@ -31,6 +31,7 @@ class Timebar extends Component {
     super()
     this.state = {
       showTimeRangeSelector: false,
+      absoluteEnd: null,
     }
   }
 
@@ -59,7 +60,7 @@ class Timebar extends Component {
 
   setBookmark = () => {
     const { start, end, onBookmarkChange } = this.props
-    onBookmarkChange(start, end)
+    onBookmarkChange !== null && onBookmarkChange(start, end)
   }
 
   onTimeRangeSelectorSubmit = (start, end) => {
@@ -258,6 +259,11 @@ class Timebar extends Component {
 }
 
 Timebar.propTypes = {
+  start: PropTypes.string.isRequired,
+  end: PropTypes.string.isRequired,
+  bookmarkStart: PropTypes.string,
+  bookmarkEnd: PropTypes.string,
+  onBookmarkChange: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
@@ -266,6 +272,9 @@ Timebar.propTypes = {
 
 Timebar.defaultProps = {
   enablePlayback: false,
+  bookmarkStart: null,
+  bookmarkEnd: null,
+  onBookmarkChange: null,
 }
 
 export default Timebar


### PR DESCRIPTION
Modify the DateSelector component to allow enter dates with the keyboard for days and years.
Use native select for months.