### PR TITLE
fixed map loading dispatchers

### DIFF
--- a/src/map/heatmap/heatmap.actions.js
+++ b/src/map/heatmap/heatmap.actions.js
@@ -138,7 +138,7 @@ function parseLayerTile(rawTileData, colsByName, isPBF, tileCoordinates, prevPla
 function getTiles(layerIds, referenceTiles, newTemporalExtentsToLoad = undefined) {
   return (dispatch, getState) => {
     const state = getState()
-    const loaderID = startLoader(dispatch, state)
+    const loaderID = startLoader(dispatch, state, layerIds.join('-'))
     const token = state.map.module.token
     const heatmapLayers = state.map.heatmap.heatmapLayers
     const tilesByLayer = {}

--- a/src/map/module/module.actions.js
+++ b/src/map/module/module.actions.js
@@ -11,11 +11,12 @@ export const initModule = (props) => (dispatch) => {
   })
 }
 
-export const startLoader = (dispatch, state) => {
-  const loaderId = new Date().getTime()
+export const startLoader = (dispatch, state, loaderId) => {
+  const timestamp = new Date().getTime()
+  const generatedLoaderId = loaderId !== undefined ? `${loaderId}_${timestamp}` : timestamp
   dispatch({
     type: START_LOADER,
-    payload: loaderId,
+    payload: generatedLoaderId,
   })
   if (state.map.module.onLoadStart !== undefined) {
     state.map.module.onLoadStart()
@@ -24,12 +25,12 @@ export const startLoader = (dispatch, state) => {
 }
 
 export const completeLoader = (loaderId) => (dispatch, getState) => {
-  const state = getState()
-  const loaders = Object.assign({}, state.map.module.loaders)
   dispatch({
     type: COMPLETE_LOADER,
     payload: loaderId,
   })
+  const state = getState()
+  const loaders = state.map.module.loaders
   if (!loaders.length && state.map.module.onLoadComplete !== undefined) {
     state.map.module.onLoadComplete()
   }


### PR DESCRIPTION
Load complete event was wrongly fired after first load because `loaders` was an object (hence .length was always undefined)
Then it was never fired because `loaders` was read before setting state (before removing last loader)
Added ids to loaders for easier debugging.