### PR TITLE
fixed heatmap first display

### DIFF
--- a/src/map/activity/ActivityLayers.js
+++ b/src/map/activity/ActivityLayers.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import * as PIXI from 'pixi.js'
 import PropTypes from 'prop-types'
 import { BaseControl } from 'react-map-gl'
@@ -86,8 +86,15 @@ const getVesselTexture = (radius, blurFactor) => {
 }
 
 class ActivityLayers extends BaseControl {
+  state = {
+    pixiReady: false,
+  }
+
   componentDidMount() {
     this._build()
+    this.setState({
+      pixiReady: true,
+    })
   }
 
   componentWillReceiveProps(nextProps) {
@@ -264,6 +271,7 @@ class ActivityLayers extends BaseControl {
       rightWorldScaled,
     } = this.props
     const { viewport } = this._context
+    const { pixiReady } = this.state
 
     const startIndex = temporalExtentIndexes[0]
     const endIndex = temporalExtentIndexes[1]
@@ -295,48 +303,52 @@ class ActivityLayers extends BaseControl {
         onMouseMove={this.onMouseMove}
         onTouchStart={this.onTouchStart}
       >
-        {heatmapLayers.map((layer) => (
-          <HeatmapLayer
-            key={layer.id}
-            layer={layer}
-            filters={layer.filters || []}
-            viewport={viewport}
-            startIndex={startIndex}
-            endIndex={endIndex}
-            baseTexture={this.baseTexture}
-            rootStage={this.heatmapStage}
-            useRadialGradientStyle={useRadialGradientStyle}
-            customRenderingStyle={{}}
-            viewportLeft={leftWorldScaled}
-            viewportRight={rightWorldScaled}
-          />
-        ))}
-        {this.stage !== undefined && (
-          <HeatmapLayer
-            key="highlighted"
-            layer={highlightLayerData}
-            filters={highlightFilters}
-            viewport={viewport}
-            startIndex={startIndex}
-            endIndex={endIndex}
-            baseTexture={this.baseTexture}
-            rootStage={this.heatmapStage}
-            useRadialGradientStyle={useRadialGradientStyle}
-            customRenderingStyle={{ defaultOpacity: 1, defaultSize: 1 }}
-            viewportLeft={leftWorldScaled}
-            viewportRight={rightWorldScaled}
-          />
-        )}
-        {this.stage !== undefined && (
-          <TracksLayer
-            tracks={tracks}
-            viewport={viewport}
-            zoom={zoom}
-            startIndex={startIndex}
-            endIndex={endIndex}
-            highlightTemporalExtentIndexes={highlightTemporalExtentIndexes}
-            rootStage={this.stage}
-          />
+        {pixiReady === true && (
+          <Fragment>
+            {heatmapLayers.map((layer) => (
+              <HeatmapLayer
+                key={layer.id}
+                layer={layer}
+                filters={layer.filters || []}
+                viewport={viewport}
+                startIndex={startIndex}
+                endIndex={endIndex}
+                baseTexture={this.baseTexture}
+                rootStage={this.heatmapStage}
+                useRadialGradientStyle={useRadialGradientStyle}
+                customRenderingStyle={{}}
+                viewportLeft={leftWorldScaled}
+                viewportRight={rightWorldScaled}
+              />
+            ))}
+            {this.stage !== undefined && (
+              <HeatmapLayer
+                key="highlighted"
+                layer={highlightLayerData}
+                filters={highlightFilters}
+                viewport={viewport}
+                startIndex={startIndex}
+                endIndex={endIndex}
+                baseTexture={this.baseTexture}
+                rootStage={this.heatmapStage}
+                useRadialGradientStyle={useRadialGradientStyle}
+                customRenderingStyle={{ defaultOpacity: 1, defaultSize: 1 }}
+                viewportLeft={leftWorldScaled}
+                viewportRight={rightWorldScaled}
+              />
+            )}
+            {this.stage !== undefined && (
+              <TracksLayer
+                tracks={tracks}
+                viewport={viewport}
+                zoom={zoom}
+                startIndex={startIndex}
+                endIndex={endIndex}
+                highlightTemporalExtentIndexes={highlightTemporalExtentIndexes}
+                rootStage={this.stage}
+              />
+            )}
+          </Fragment>
         )}
       </div>
     )

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -151,6 +151,9 @@ class MapModule extends React.Component {
     this.setState({
       initialized: true,
     })
+
+    // heatmap layers
+    store.dispatch(updateHeatmapLayers(this.props.heatmapLayers, this.props.loadTemporalExtent))
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Because `map-client` now loads the Map lazily, we need to adds a call to update heatmap layers when the Map module mounts. This caused an issue in ActivityLayers, as heatmap layers instances need the Pixi root, which in turn needs the container div created in ActivityLayers.

This fixes it by doing the following in order:
1. trigger a render on ActivityLayers, that will set up the ref for the div container. Heatmap Layers not rendered at this point
2. call componentDidMount, set a flag on the state, which will
3. trigger another render, this time with all Heatmap Layers

This is not ideal and is probably better handled with hooks, but this will do for now. Performance-wise, impact should be neglectible as the first render is only a single div with no children (and later, children don't even render any DOM)