### PR TITLE
Carrier portal features

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/GlobalFishingWatch/map-components",
   "main": "components/index.js",
+  "typings": "types/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"
@@ -66,6 +67,9 @@
     "@babel/preset-react": "^7.0.0",
     "@satellitestudio/eslint-config": "^1.1.0",
     "@svgr/rollup": "^4.1.0",
+    "@types/react": "^16.8.16",
+    "@typescript-eslint/eslint-plugin": "^1.7.0",
+    "@typescript-eslint/parser": "^1.7.0",
     "autoprefixer": "^9.5.0",
     "babel-eslint": "9.x",
     "babel-loader": "8.0.4",
@@ -75,16 +79,15 @@
     "docz-plugin-css": "^0.11.0",
     "docz-theme-default": "0.13.7",
     "dotenv": "^6.2.0",
-    "eslint": "5.x",
+    "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-config-react-app": "4.0.0",
-    "eslint-plugin-flowtype": "2.x",
-    "eslint-plugin-import": "2.x",
-    "eslint-plugin-jsx-a11y": "6.x",
+    "eslint-config-react-app": "^4.0.0",
+    "eslint-plugin-flowtype": "^3.6.1",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "7.x",
+    "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "gh-pages": "^2.0.1",
     "husky": "^1.3.1",
     "imagemin-lint-staged": "^0.4.0",
     "lint-staged": "^8.1.1",
@@ -113,7 +116,8 @@
     "rollup-plugin-url": "^2.2.0",
     "rollup-plugin-visualizer": "^1.0.2",
     "stylelint": "^9.10.1",
-    "stylelint-config-standard": "^18.2.0"
+    "stylelint-config-standard": "^18.2.0",
+    "typescript": "^3.4.5"
   },
   "husky": {
     "hooks": {
@@ -121,6 +125,7 @@
     }
   },
   "files": [
-    "components"
+    "components",
+    "types"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "https://github.com/GlobalFishingWatch/map-components",
   "main": "components/index.js",
-  "typings": "types/index.d.ts",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=5"
@@ -88,6 +88,7 @@
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
+    "gh-pages": "^2.0.1",
     "husky": "^1.3.1",
     "imagemin-lint-staged": "^0.4.0",
     "lint-staged": "^8.1.1",

--- a/src/countryflag/countryflag.js
+++ b/src/countryflag/countryflag.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import countryflag from 'countryflag'
 
-class CountryFlag extends Component {
+class CountryFlag extends PureComponent {
   render() {
     // iso2 is deprecated, ignoring prop-types
     // eslint-disable-next-line react/prop-types

--- a/src/map/README.md
+++ b/src/map/README.md
@@ -243,7 +243,9 @@ Object. If specified, overrides all style info with raw Mapbox GL JSON styles, f
 
 ## `basemapLayers`
 
-TODO
+Available basemap layers by id:
+
+`'satellite', 'north-star', 'labels', 'graticules', 'bathymetry'`
 
 basemapLayers: PropTypes.arrayOf(PropTypes.shape({
 id: PropTypes.string,

--- a/src/map/README.md
+++ b/src/map/README.md
@@ -187,18 +187,20 @@ A filter to apply specific rules per polygon. Polygon filter is defined as: Obje
 
 - `field`: String. A filterable field.
 - `values`: Array. All selected values (logical OR).
-- `style`: [NOT IMPLEMENTED] Object. Defines for each GL paint property (`fill-color`, etc) rules for selected and non selected objects, ie:
+- `style`: Object. Defines for each GL type, then GL paint property (`fill-color`, etc) rules for selected and non selected objects, ie:
 
 ```
 style: {
-'fill-color': [
-    SELECTED COLOR,
-    DEFAULT COLOR
-],
-'fill-opacity': [
-    SELECTED OPACITY,
-    DEFAULT OPACITY
-]
+    fill: {
+        'fill-color': [
+            SELECTED COLOR,
+            DEFAULT COLOR
+        ],
+        'fill-opacity': [
+            SELECTED OPACITY,
+            DEFAULT OPACITY
+        ]
+    }
 }
 ```
 
@@ -295,6 +297,7 @@ Function. Called when a user clicks on the close button of a click popup.
 ## `onViewportChange`
 
 Callback that returns the following properties:
+
 ```js
 {
     interactionState, // interaction that triggered the change see
@@ -319,6 +322,7 @@ Function. TODO
 ## `onClick`
 
 Function. Returns an event:
+
 ```
     {
         latitude,

--- a/src/map/README.md
+++ b/src/map/README.md
@@ -62,7 +62,7 @@ Boolean. Default true. Have the map zoom in to an appropriate zoom level when us
 
 ### `isCluster`
 
-Function. Default `(event) => event.isCluster === true`. Allows fine-tuning determining cluster behavior or not (with `autoClusterZoom` set to true), given an event with a list of features. 
+Function. Default `(event) => event.isCluster === true`. Allows fine-tuning determining cluster behavior or not (with `autoClusterZoom` set to true), given an event with a list of features.
 
 ## `tracks`
 
@@ -292,7 +292,19 @@ Function. Called when a user clicks on the close button of a click popup.
 
 ## `onViewportChange`
 
-Function. TODO
+Callback that returns the following properties:
+```js
+{
+    interactionState, // interaction that triggered the change see
+    // https://github.com/uber/react-map-gl/blob/master/docs/components/interactive-map.md#oninteractionstatechange-function
+    zoom: viewport.viewport.zoom,
+    center: [viewport.viewport.latitude, viewport.viewport.longitude],
+    bounds: viewport.bounds,
+    canZoomIn: viewport.canZoomIn,
+    canZoomOut: viewport.canZoomOut,
+    mouseLatLong: viewport.mouseLatLong,
+}
+```
 
 ## `onLoadStart`
 

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -75,17 +75,8 @@ const getCursor = createSelector(
     return internalCursor
   }
 )
-
-const defaultTransitions = {}
-const transitions = {
-  transitionDuration: 300,
-  transitionEasing: easeCubicInOut,
-  transitionInterpolator: new LinearInterpolator(),
-}
-
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   viewport: state.map.viewport.viewport,
-  transitions: ownProps.transitionsEnabled === true ? transitions : defaultTransitions,
   maxZoom: state.map.viewport.maxZoom,
   minZoom: state.map.viewport.minZoom,
   cursor: getCursor(state),

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -2,6 +2,8 @@ import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
 import { fromJS } from 'immutable'
 import { TRACKS_LAYER_IN_FRONT_OF_GROUP } from '../config'
+import LinearInterpolator from 'react-map-gl/dist/esm/utils/transition/linear-interpolator'
+import { easeCubicInOut } from 'd3-ease'
 import { closePopup } from '../module/module.actions.js'
 import { getTracksStyles } from '../tracks/tracks.selectors.js'
 import { mapInteraction } from './interaction.actions.js'
@@ -59,8 +61,16 @@ const getCursor = createSelector(
   }
 )
 
+const defaultTransitions = {}
+const transitions = {
+  transitionDuration: 200,
+  transitionEasing: easeCubicInOut,
+  transitionInterpolator: new LinearInterpolator(),
+}
+
 const mapStateToProps = (state) => ({
   viewport: state.map.viewport.viewport,
+  transitions: ownProps.transitionsEnabled === true ? transitions : defaultTransitions,
   maxZoom: state.map.viewport.maxZoom,
   minZoom: state.map.viewport.minZoom,
   cursor: getCursor(state),

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -63,7 +63,7 @@ const getCursor = createSelector(
 
 const defaultTransitions = {}
 const transitions = {
-  transitionDuration: 200,
+  transitionDuration: 300,
   transitionEasing: easeCubicInOut,
   transitionInterpolator: new LinearInterpolator(),
 }

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -31,7 +31,10 @@ const getInteractiveLayerIds = createSelector(
         layer.gl.layers.forEach((glLayer, index) => {
           // layers.length === 1 is used to ensure when parent layer is marked as interactive we have to
           // have at least one interactive sublayer, then checked eah one individually
-          if (layer.gl.layers.length === 1 || glLayer.interactive === true) {
+          if (
+            layer.gl.layers.length === 1 ||
+            (glLayer.metadata !== undefined && glLayer.metadata['gfw:interactive'] === true)
+          ) {
             const glLayerId = glLayer.id || index > 0 ? `${layer.id}-${index}` : layer.id
             acc.push(glLayerId)
           }

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -96,8 +96,8 @@ const mapStateToProps = (state) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-  setViewport: (viewport) => {
-    dispatch(setViewport(viewport))
+  setViewport: (viewport, interactionState) => {
+    dispatch(setViewport(viewport, interactionState))
   },
   mapInteraction: (type, lat, long, features, cluster, glGetSource) => {
     dispatch(mapInteraction(type, lat, long, features, cluster, glGetSource))

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -25,8 +25,23 @@ const getInteractiveLayerIds = createSelector(
   [getStaticLayers],
   // Note: here we assume that layer IDs provided with module match the GL layers that should
   // be interactive or not, ie typically the fill layer if a label layer is present
-  (staticLayers) =>
-    staticLayers.filter((l) => l.interactive === true && l.visible === true).map((l) => l.id)
+  (staticLayers) => {
+    return staticLayers.reduce((acc, layer) => {
+      if (!layer.interactive || !layer.visible) return acc
+      // We also need to check nested layers interactivity when custom gl layers are provided
+      if (layer.gl !== undefined) {
+        layer.gl.layers.forEach((glLayer, index) => {
+          if (index === 0 || glLayer.interactive === true) {
+            const glLayerId = glLayer.id || index > 0 ? `${layer.id}-${index}` : layer.id
+            acc.push(glLayerId)
+          }
+        })
+      } else {
+        acc.push(layer.id)
+      }
+      return acc
+    }, [])
+  }
 )
 
 const getMapStyles = (state) => state.map.style.mapStyle

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -2,8 +2,6 @@ import { connect } from 'react-redux'
 import { createSelector } from 'reselect'
 import { fromJS } from 'immutable'
 import { TRACKS_LAYER_IN_FRONT_OF_GROUP } from '../config'
-import LinearInterpolator from 'react-map-gl/dist/esm/utils/transition/linear-interpolator'
-import { easeCubicInOut } from 'd3-ease'
 import { closePopup } from '../module/module.actions.js'
 import { getTracksStyles } from '../tracks/tracks.selectors.js'
 import { mapInteraction } from './interaction.actions.js'
@@ -31,7 +29,9 @@ const getInteractiveLayerIds = createSelector(
       // We also need to check nested layers interactivity when custom gl layers are provided
       if (layer.gl !== undefined) {
         layer.gl.layers.forEach((glLayer, index) => {
-          if (index === 0 || glLayer.interactive === true) {
+          // layers.length === 1 is used to ensure when parent layer is marked as interactive we have to
+          // have at least one interactive sublayer, then checked eah one individually
+          if (layer.gl.layers.length === 1 || glLayer.interactive === true) {
             const glLayerId = glLayer.id || index > 0 ? `${layer.id}-${index}` : layer.id
             acc.push(glLayerId)
           }

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -139,7 +139,7 @@ class Map extends React.Component {
       markers,
       interactiveLayerIds,
     } = this.props
-    console.log('TCL: render -> mapStyle', mapStyle.toJS())
+
     return (
       <div
         id="map"

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -217,7 +217,13 @@ Map.propTypes = {
   transitionEnd: PropTypes.func,
   cursor: PropTypes.string,
   hasHeatmapLayers: PropTypes.bool.isRequired,
-  markers: PropTypes.array,
+  markers: PropTypes.arrayOf(
+    PropTypes.shape({
+      latitude: PropTypes.number.isRequired,
+      longitude: PropTypes.number.isRequired,
+      content: PropTypes.node,
+    })
+  ),
   interactiveLayerIds: PropTypes.arrayOf(PropTypes.string),
 }
 

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -128,7 +128,6 @@ class Map extends React.Component {
   render() {
     const {
       viewport,
-      transitions,
       maxZoom,
       minZoom,
       transitionEnd,
@@ -140,6 +139,7 @@ class Map extends React.Component {
       markers,
       interactiveLayerIds,
     } = this.props
+    console.log('TCL: render -> mapStyle', mapStyle.toJS())
     return (
       <div
         id="map"
@@ -156,7 +156,6 @@ class Map extends React.Component {
       >
         <MapGL
           {...viewport}
-          {...transitions}
           ref={this.getRef}
           transformRequest={this.transformRequest}
           onTransitionEnd={transitionEnd}
@@ -206,7 +205,6 @@ class Map extends React.Component {
 
 Map.propTypes = {
   token: PropTypes.string,
-  transitions: PropTypes.object.isRequired,
   viewport: PropTypes.object.isRequired,
   mapStyle: PropTypes.object.isRequired,
   clickPopup: PropTypes.object,

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import MapGL, { Popup } from 'react-map-gl'
+import MapGL, { Popup, Marker } from 'react-map-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { TILES_URL_NEEDING_AUTHENTICATION } from '../config'
 import ActivityLayers from '../activity/ActivityLayers.container.js'
@@ -137,6 +137,7 @@ class Map extends React.Component {
       clickPopup,
       hoverPopup,
       hasHeatmapLayers,
+      markers,
       interactiveLayerIds,
     } = this.props
     return (
@@ -189,6 +190,13 @@ class Map extends React.Component {
               {hoverPopup.content}
             </PopupWrapper>
           )}
+          {markers !== null &&
+            markers.length &&
+            markers.map((marker, i) => (
+              <Marker key={i} latitude={marker.latitude} longitude={marker.longitude}>
+                {marker.content}
+              </Marker>
+            ))}
         </MapGL>
         <div className={styles.googleLogo} />
       </div>
@@ -211,6 +219,7 @@ Map.propTypes = {
   transitionEnd: PropTypes.func,
   cursor: PropTypes.string,
   hasHeatmapLayers: PropTypes.bool.isRequired,
+  markers: PropTypes.array,
   interactiveLayerIds: PropTypes.arrayOf(PropTypes.string),
 }
 
@@ -222,6 +231,7 @@ Map.defaultProps = {
   onClosePopup: () => {},
   transitionEnd: () => {},
   cursor: null,
+  markers: null,
   interactiveLayerIds: null,
 }
 

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -128,6 +128,7 @@ class Map extends React.Component {
   render() {
     const {
       viewport,
+      transitions,
       maxZoom,
       minZoom,
       transitionEnd,
@@ -153,6 +154,8 @@ class Map extends React.Component {
         }}
       >
         <MapGL
+          {...viewport}
+          {...transitions}
           ref={this.getRef}
           transformRequest={this.transformRequest}
           onTransitionEnd={transitionEnd}
@@ -160,7 +163,6 @@ class Map extends React.Component {
           onClick={this.onClick}
           getCursor={this.getCursor}
           mapStyle={mapStyle}
-          {...viewport}
           maxZoom={maxZoom}
           minZoom={minZoom}
           onViewportChange={this.onViewportChange}
@@ -196,6 +198,7 @@ class Map extends React.Component {
 
 Map.propTypes = {
   token: PropTypes.string,
+  transitions: PropTypes.object.isRequired,
   viewport: PropTypes.object.isRequired,
   mapStyle: PropTypes.object.isRequired,
   clickPopup: PropTypes.object,

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -78,8 +78,8 @@ class Map extends React.Component {
     }
   }
 
-  onViewportChange = (viewport) => {
-    this.props.setViewport(viewport)
+  onViewportChange = (viewport, interactionState) => {
+    this.props.setViewport(viewport, interactionState)
   }
 
   onMapInteraction = (event, type) => {

--- a/src/map/glmap/gl-styles/style.json
+++ b/src/map/glmap/gl-styles/style.json
@@ -783,13 +783,8 @@
         "mapbox:group": "tools"
       },
       "paint": {
-        "line-dasharray": [2,1],
-        "line-width": [
-          "case",
-          ["==", ["get", "isNew"], true],
-          1.5,
-          1
-        ]
+        "line-dasharray": [2, 1],
+        "line-width": ["case", ["==", ["get", "isNew"], true], 1.5, 1]
       }
     },
     {
@@ -807,12 +802,7 @@
           ["literal", ["Roboto Medium"]],
           ["literal", ["Roboto Mono Light"]]
         ],
-        "text-size": [
-          "case",
-          ["==", ["get", "isNew"], true],
-          13,
-          12
-        ]
+        "text-size": ["case", ["==", ["get", "isNew"], true], 13, 12]
       },
       "metadata": {
         "mapbox:group": "tools"
@@ -823,12 +813,7 @@
       "source": "rulers-points",
       "type": "circle",
       "paint": {
-        "circle-radius": [
-          "case",
-          ["==", ["get", "isNew"], true],
-          6,
-          3
-        ],
+        "circle-radius": ["case", ["==", ["get", "isNew"], true], 6, 3],
         "circle-opacity": 1,
         "circle-stroke-opacity": 0
       }

--- a/src/map/glmap/gl-styles/style.json
+++ b/src/map/glmap/gl-styles/style.json
@@ -153,6 +153,13 @@
       },
       "type": "vector"
     },
+    "cp_rfmo": {
+      "metadata": {
+        "gfw:carto-sql": "SELECT the_geom, the_geom_webmercator, cartodb_id, id, id as rfb FROM carrier_portal_rfmo_hi_res",
+        "gfw:popups": [{ "id": "rfb" }, { "id": "POLYGON_LAYERS_AREA" }]
+      },
+      "type": "vector"
+    },
     "6": {
       "metadata": {
         "gfw:carto-sql": "select * from kkp_regions",
@@ -417,6 +424,15 @@
       "type": "fill",
       "source": "rfmo",
       "source-layer": "rfmo"
+    },
+    {
+      "id": "cp_rfmo",
+      "metadata": {
+        "mapbox:group": "static"
+      },
+      "type": "fill",
+      "source": "cp_rfmo",
+      "source-layer": "cp_rfmo"
     },
     {
       "id": "rfmo-labels",

--- a/src/map/glmap/interaction.actions.js
+++ b/src/map/glmap/interaction.actions.js
@@ -209,7 +209,7 @@ export const mapInteraction = (interactionType, latitude, longitude, glFeatures,
     }
 
     let cursor = event.features.length ? 'pointer' : null
-    if (event.isCluster === true && autoClusterZoom === true) {
+    if (event.isCluster === true) {
       cursor = 'zoom-in'
     }
 

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -102,13 +102,15 @@ const applyLayerExpressions = (style, refLayer, currentGlLayer, glLayerIndex) =>
   ;['selected', 'highlighted'].forEach((styleType) => {
     // get selectedFeatures or highlightedFeatures
     const features = refLayer[`${styleType}Features`]
+    const refLayerStyle = features && features.style ? features.style[glType] : {}
     const hasFeatures = features !== null && features !== undefined && features.values.length > 0
     const applyStyleToAllFeatures = refLayer[styleType]
 
     const defaultStyle = defaultStyles[styleType][glType] || {}
     const layerStyle =
       (metadata && metadata['gfw:styles'] && metadata['gfw:styles'][styleType]) || {}
-    const allPaintProperties = { ...defaultStyle, ...layerStyle }
+    const allPaintProperties = { ...defaultStyle, ...layerStyle, ...refLayerStyle }
+
     if (Object.keys(allPaintProperties).length) {
       // go through each applicable gl paint property
       Object.keys(allPaintProperties).forEach((glPaintProperty) => {

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -321,11 +321,10 @@ const updateWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
       .toJS()
       .map((l) => l.id)
     const layersToAdd = gl.layers.filter((l) => !existingLayerIds.includes(l.id))
-    layersToAdd.forEach((layerToAdd) => {
-
-      let layerToAddId = id
-      if (gl.layers.length > 1) {
-        layerToAddId = `${id}-${new Date().getTime()}`
+    layersToAdd.forEach((layerToAdd, index) => {
+      let layerToAddId = layerToAdd.id
+      if (!layerToAddId && gl.layers.length > 1) {
+        layerToAddId = `${id}-${index}`
       }
       const defaultGlLayer = setLayerStyleDefaults(layerToAdd)
 
@@ -338,7 +337,7 @@ const updateWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
       // set source-layer - defaults to source id
       if (gl.source.type === 'vector') {
         const sourceLayer =
-          workspaceGlLayer['source-layer'] === undefined ? id : workspaceGlLayer['source-layer']
+          workspaceGLLayer['source-layer'] === undefined ? id : workspaceGLLayer['source-layer']
         glLayer['source-layer'] = sourceLayer
       }
 

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -207,9 +207,10 @@ const updateGLLayer = (style, glLayerId, refLayer) => {
       break
     }
     case 'line': {
+      const color = refLayer.color || (glLayer.paint && glLayer.paint['line-color'])
       newStyle = newStyle
         .setIn(['layers', glLayerIndex, 'paint', 'line-opacity'], refLayerOpacity)
-        .setIn(['layers', glLayerIndex, 'paint', 'line-color'], refLayer.color)
+        .setIn(['layers', glLayerIndex, 'paint', 'line-color'], color)
       break
     }
     case 'symbol': {
@@ -410,7 +411,7 @@ const instanciateCartoLayers = (layers) => (dispatch, getState) => {
           })
         )
 
-        // change source in all layers that are using it (genrally polygon + labels)
+        // change source in all layers that are using it (generally polygon + labels)
         currentStyle.layers.forEach((glLayer, glLayerIndex) => {
           if (glLayer.source === cartoLayer.sourceId) {
             style = style.setIn(['layers', glLayerIndex, 'source'], newSourceId)

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -320,12 +320,13 @@ const updateWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
       .get('layers')
       .toJS()
       .map((l) => l.id)
-    const layersToAdd = gl.layers.filter((l) => !existingLayerIds.includes(l.id))
+    const layersToAdd = gl.layers.filter((layer, index) => {
+      const layerId = layer.id || index > 0 ? `${id}-${index}` : id
+      return !existingLayerIds.includes(layerId)
+    })
     layersToAdd.forEach((layerToAdd, index) => {
-      let layerToAddId = layerToAdd.id
-      if (!layerToAddId && gl.layers.length > 1) {
-        layerToAddId = `${id}-${index}`
-      }
+      // doesn't add a sufix in the first elements but it will for the following ones
+      let layerToAddId = layerToAdd.id || index > 0 ? `${id}-${index}` : id
       const defaultGlLayer = setLayerStyleDefaults(layerToAdd)
 
       const glLayer = {

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -341,7 +341,7 @@ const updateWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
       // set source-layer - defaults to source id
       if (gl.source.type === 'vector') {
         const sourceLayer =
-          workspaceGLLayer['source-layer'] === undefined ? id : workspaceGLLayer['source-layer']
+          layerToAdd['source-layer'] === undefined ? id : layerToAdd['source-layer']
         glLayer['source-layer'] = sourceLayer
       }
 

--- a/src/map/glmap/viewport.actions.js
+++ b/src/map/glmap/viewport.actions.js
@@ -42,8 +42,8 @@ const transitionTo = (increment, latitude = null, longitude = null, zoom = null)
   dispatch(onViewportChange())
 }
 
-export const transitionToZoom = (zoom) => (dispatch) => {
-  dispatch(transitionTo(null, null, null, zoom))
+export const transitionToZoom = (viewport) => (dispatch) => {
+  dispatch(transitionTo(null, viewport.center[0], viewport.center[1], viewport.zoom))
 }
 
 export const transitionEnd = () => (dispatch) => {

--- a/src/map/glmap/viewport.actions.js
+++ b/src/map/glmap/viewport.actions.js
@@ -10,13 +10,13 @@ export const SET_MOUSE_LAT_LONG = 'SET_MOUSE_LAT_LONG'
 export const TRANSITION_END = 'TRANSITION_END'
 export const SET_NATIVE_VIEWPORT = 'SET_NATIVE_VIEWPORT'
 
-export const setViewport = (viewport) => (dispatch) => {
+export const setViewport = (viewport, interactionState) => (dispatch) => {
   dispatch({
     type: SET_VIEWPORT,
     payload: viewport,
   })
   dispatch(updateHeatmapTilesFromViewport())
-  dispatch(onViewportChange())
+  dispatch(onViewportChange(interactionState))
 }
 
 export const updateViewport = (viewportUpdate) => (dispatch) => {

--- a/src/map/glmap/viewport.reducer.js
+++ b/src/map/glmap/viewport.reducer.js
@@ -1,4 +1,4 @@
-import FlyToInterpolator from 'react-map-gl/dist/es5/utils/transition/viewport-fly-to-interpolator'
+import FlyToInterpolator from 'react-map-gl/dist/esm/utils/transition/viewport-fly-to-interpolator'
 import { easeCubic } from 'd3-ease'
 import { MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL } from '../config'
 import { TRANSITION_TYPE } from '../constants'

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,3 +1,9 @@
 export { default } from './map'
 export { targetMapVessel } from './store'
 export { default as AVAILABLE_BASEMAPS } from './basemaps'
+// export {
+//   default as LinearInterpolator,
+// } from 'react-map-gl/dist/esm/utils/transition/linear-interpolator'
+// export {
+//   default as FlyToInterpolator,
+// } from 'react-map-gl/dist/esm/utils/transition/viewport-fly-to-interpolator'

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,9 +1,3 @@
 export { default } from './map'
 export { targetMapVessel } from './store'
 export { default as AVAILABLE_BASEMAPS } from './basemaps'
-// export {
-//   default as LinearInterpolator,
-// } from 'react-map-gl/dist/esm/utils/transition/linear-interpolator'
-// export {
-//   default as FlyToInterpolator,
-// } from 'react-map-gl/dist/esm/utils/transition/viewport-fly-to-interpolator'

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -216,7 +216,7 @@ class MapModule extends React.Component {
       ) {
         // if zoom delta is precisely === 1, zoom with a transition
         if (Math.abs(currentViewport.zoom - this.props.viewport.zoom) === 1) {
-          store.dispatch(transitionToZoom(this.props.viewport.zoom))
+          store.dispatch(transitionToZoom(this.props.viewport))
         } else {
           updateViewportFromIncomingProps(this.props.viewport)
         }

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -250,7 +250,6 @@ class MapModule extends React.Component {
 
 MapModule.propTypes = {
   token: PropTypes.string,
-  transitionsEnabled: PropTypes.bool,
   viewport: PropTypes.shape(viewportTypes).isRequired,
   autoClusterZoom: PropTypes.bool,
   isCluster: PropTypes.func,
@@ -277,7 +276,6 @@ MapModule.propTypes = {
 
 MapModule.defaultProps = {
   token: null,
-  transitionsEnabled: false,
   glyphsPath: null,
   autoClusterZoom: true,
   isCluster: (event) => event.isCluster === true,

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -250,6 +250,7 @@ class MapModule extends React.Component {
 
 MapModule.propTypes = {
   token: PropTypes.string,
+  transitionsEnabled: PropTypes.bool,
   viewport: PropTypes.shape(viewportTypes).isRequired,
   autoClusterZoom: PropTypes.bool,
   isCluster: PropTypes.func,
@@ -276,6 +277,7 @@ MapModule.propTypes = {
 
 MapModule.defaultProps = {
   token: null,
+  transitionsEnabled: false,
   glyphsPath: null,
   autoClusterZoom: true,
   isCluster: (event) => event.isCluster === true,

--- a/src/map/module/module.actions.js
+++ b/src/map/module/module.actions.js
@@ -37,7 +37,7 @@ export const completeLoader = (loaderId) => (dispatch, getState) => {
   }
 }
 
-export const onViewportChange = () => (dispatch, getState) => {
+export const onViewportChange = (interactionState) => (dispatch, getState) => {
   const state = getState()
   const callback = state.map.module.onViewportChange
 
@@ -47,6 +47,7 @@ export const onViewportChange = () => (dispatch, getState) => {
   const viewport = state.map.viewport
 
   callback({
+    interactionState,
     zoom: viewport.viewport.zoom,
     center: [viewport.viewport.latitude, viewport.viewport.longitude],
     bounds: viewport.bounds,

--- a/src/map/module/module.actions.js
+++ b/src/map/module/module.actions.js
@@ -46,10 +46,6 @@ export const onViewportChange = () => (dispatch, getState) => {
   }
   const viewport = state.map.viewport
 
-  if (viewport.bounds === undefined) {
-    return
-  }
-
   callback({
     zoom: viewport.viewport.zoom,
     center: [viewport.viewport.latitude, viewport.viewport.longitude],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+      "module": "commonjs",
+      "lib": [
+          "es6"
+      ],
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "strictFunctionTypes": true,
+      "strictNullChecks": true,
+      "baseUrl": "./src",
+      "typeRoots": [
+          "./types"
+      ],
+      "types": [],
+      "noEmit": true,
+      "forceConsistentCasingInFileNames": true,
+      "esModuleInterop": true
+  },
+  "files": [
+      "types/index.d.ts",
+  ]
+}

--- a/types/components/countryflag.d.ts
+++ b/types/components/countryflag.d.ts
@@ -1,0 +1,17 @@
+import * as React from 'react'
+
+export interface CountryFlagMargin {
+  left?: string
+  righ?: string
+}
+
+export interface CountryFlagProps {
+  iso: string
+  svg?: boolean
+  size?: string
+  margin?: CountryFlagMargin
+}
+
+export default class CountryFlag extends React.PureComponent<CountryFlagProps, any> {
+  render(): JSX.Element
+}

--- a/types/components/map.d.ts
+++ b/types/components/map.d.ts
@@ -78,10 +78,17 @@ export interface MapModuleClickPopup {
   longitude: number
 }
 
+export interface MapModuleMarker {
+  latitude: number
+  longitude: number
+  content: React.ReactNode
+}
+
 export interface MapModuleProps {
   viewport: MapModuleViewport
   token?: string
   transitionsEnabled?: boolean
+  markers: MapModuleMarker[]
   tracks?: MapModuleTrack[]
   heatmapLayers?: MapModuleHeatmapLayers[]
   temporalExtent?: Date[]

--- a/types/components/map.d.ts
+++ b/types/components/map.d.ts
@@ -1,0 +1,95 @@
+import * as React from 'react'
+
+export interface MapModuleViewport {
+  zoom?: number
+  center?: number[]
+}
+
+export interface MapModuleHeatmapLayers {
+  id: string
+  tilesetId?: string
+  subtype?: string
+  visible?: boolean
+  hue?: number
+  opacity?: number
+  filters?: {
+    hue?: number
+    filterValues?: Object
+  }[]
+  header: {
+    endpoints?: Object
+    isPBF?: boolean
+    colsByName?: Object
+    temporalExtents?: (number[])[]
+    temporalExtentsLess?: boolean
+  }
+  interactive?: boolean
+}
+
+export interface MapModuleBasemapLayers {
+  id?: string
+  visible?: boolean
+}
+
+export interface MapModuleStaticLayers {
+  id: string
+  visible?: boolean
+  selected?: boolean
+  selectedFeatures?: {
+    field?: string
+    values?: string[]
+  }
+  highlighted?: boolean
+  higlightedFeatures?: {
+    field?: string
+    values?: string[]
+  }
+  opacity?: number
+  color?: string
+  showLabels?: boolean
+  interactive?: boolean
+  filters?: (string[])[]
+  isCustom?: boolean
+  subtype?: any
+  url?: string
+  data?: Object
+  gl?: Object
+}
+
+export interface MapModuleHoverPopup {
+  content?: React.ReactNode
+  latitude: number
+  longitude: number
+}
+
+export interface MapModuleClickPopup {
+  content?: React.ReactNode
+  latitude: number
+  longitude: number
+}
+
+export interface MapModuleProps {
+  token?: string
+  viewport: MapModuleViewport
+  tracks?: any[]
+  heatmapLayers?: MapModuleHeatmapLayers[]
+  temporalExtent?: Date[]
+  highlightTemporalExtent?: Date[]
+  loadTemporalExtent?: Date[]
+  basemapLayers?: MapModuleBasemapLayers[]
+  staticLayers?: MapModuleStaticLayers[]
+  hoverPopup?: MapModuleHoverPopup
+  clickPopup?: MapModuleClickPopup
+  glyphsPath?: string
+  onViewportChange?: (...args: any[]) => any
+  onLoadStart?: (...args: any[]) => any
+  onLoadComplete?: (...args: any[]) => any
+  onClick?: (...args: any[]) => any
+  onHover?: (...args: any[]) => any
+  onAttributionsChange?: (...args: any[]) => any
+  onClosePopup?: (...args: any[]) => any
+}
+
+export default class MapModule extends React.Component<MapModuleProps, any> {
+  render(): JSX.Element
+}

--- a/types/components/map.d.ts
+++ b/types/components/map.d.ts
@@ -87,7 +87,6 @@ export interface MapModuleMarker {
 export interface MapModuleProps {
   viewport: MapModuleViewport
   token?: string
-  transitionsEnabled?: boolean
   markers: MapModuleMarker[]
   tracks?: MapModuleTrack[]
   heatmapLayers?: MapModuleHeatmapLayers[]

--- a/types/components/map.d.ts
+++ b/types/components/map.d.ts
@@ -1,8 +1,18 @@
 import * as React from 'react'
 
 export interface MapModuleViewport {
-  zoom?: number
-  center?: number[]
+  zoom: number
+  center: number[]
+}
+
+export interface MapModuleTrack {
+  id: string
+  url?: string
+  data?: object
+  color?: string
+  type?: string
+  layerTemporalExtents?: Array<Array<number>>
+  fitBoundsOnLoad?: boolean
 }
 
 export interface MapModuleHeatmapLayers {
@@ -69,9 +79,10 @@ export interface MapModuleClickPopup {
 }
 
 export interface MapModuleProps {
-  token?: string
   viewport: MapModuleViewport
-  tracks?: any[]
+  token?: string
+  transitionsEnabled?: boolean
+  tracks?: MapModuleTrack[]
   heatmapLayers?: MapModuleHeatmapLayers[]
   temporalExtent?: Date[]
   highlightTemporalExtent?: Date[]

--- a/types/components/map.d.ts
+++ b/types/components/map.d.ts
@@ -87,7 +87,7 @@ export interface MapModuleMarker {
 export interface MapModuleProps {
   viewport: MapModuleViewport
   token?: string
-  markers: MapModuleMarker[]
+  markers?: MapModuleMarker[]
   tracks?: MapModuleTrack[]
   heatmapLayers?: MapModuleHeatmapLayers[]
   temporalExtent?: Date[]

--- a/types/components/miniglobe.d.ts
+++ b/types/components/miniglobe.d.ts
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+export interface MiniGlobeBounds {
+  north?: number
+  south?: number
+  west?: number
+  east?: number
+}
+
+export interface MiniGlobeProps {
+  center: number[]
+  zoom: number
+  bounds: MiniGlobeBounds
+  size: number
+  viewportThickness: number
+}
+
+export default class MiniGlobe extends React.Component<MiniGlobeProps, any> {
+  render(): JSX.Element
+}

--- a/types/components/timebar.d.ts
+++ b/types/components/timebar.d.ts
@@ -1,0 +1,12 @@
+import * as React from 'react'
+
+export interface TimebarProps {
+  onChange: (...args: any[]) => any
+  absoluteStart: string
+  absoluteEnd: string
+  enablePlayback?: boolean
+}
+
+export default class Timebar extends React.Component<TimebarProps, any> {
+  render(): JSX.Element
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,8 @@
+export { default as CountryFlag } from './components/countryflag'
+export { default as Miniglobe } from './components/miniglobe'
+export { default as Timebar } from './components/timebar'
+export { default as Map } from './components/map'
+
+// declare module '@globalfishingwatch/map-components/components/countryflag' {
+//   export = CountryFlag;
+// }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5820,6 +5820,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+email-addresses@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.0.3.tgz#fc3c6952f68da24239914e982c8a7783bc2ed96d"
+  integrity sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==
+
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
@@ -6832,10 +6837,32 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
+filename-reserved-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz#e61cf805f0de1c984567d0386dc5df50ee5af7e4"
+  integrity sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=
+
 filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
   integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
+
+filenamify-url@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/filenamify-url/-/filenamify-url-1.0.0.tgz#b32bd81319ef5863b73078bed50f46a4f7975f50"
+  integrity sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=
+  dependencies:
+    filenamify "^1.0.0"
+    humanize-url "^1.0.0"
+
+filenamify@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-1.2.1.tgz#a9f2ffd11c503bed300015029272378f1f1365a5"
+  integrity sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=
+  dependencies:
+    filename-reserved-regex "^1.0.0"
+    strip-outer "^1.0.0"
+    trim-repeated "^1.0.0"
 
 filenamify@^2.0.0:
   version "2.1.0"
@@ -7365,6 +7392,20 @@ getport@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
   integrity sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=
+
+gh-pages@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-2.0.1.tgz#aefe47a43b8d9d2aa3130576b33fe95641e29a2f"
+  integrity sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==
+  dependencies:
+    async "^2.6.1"
+    commander "^2.18.0"
+    email-addresses "^3.0.1"
+    filenamify-url "^1.0.0"
+    fs-extra "^7.0.0"
+    globby "^6.1.0"
+    graceful-fs "^4.1.11"
+    rimraf "^2.6.2"
 
 gifsicle@^4.0.0:
   version "4.0.1"
@@ -8155,6 +8196,14 @@ humanize-string@^1.0.2:
   integrity sha512-PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==
   dependencies:
     decamelize "^1.0.0"
+
+humanize-url@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/humanize-url/-/humanize-url-1.0.1.tgz#f4ab99e0d288174ca4e1e50407c55fbae464efff"
+  integrity sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=
+  dependencies:
+    normalize-url "^1.0.0"
+    strip-url-auth "^1.0.0"
 
 husky@^1.3.1:
   version "1.3.1"
@@ -11574,6 +11623,16 @@ normalize-url@2.0.1:
     query-string "^5.0.1"
     sort-keys "^2.0.0"
 
+normalize-url@^1.0.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
+  integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
+  dependencies:
+    object-assign "^4.0.1"
+    prepend-http "^1.0.0"
+    query-string "^4.1.0"
+    sort-keys "^1.0.0"
+
 normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
@@ -13201,7 +13260,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.1:
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -13456,6 +13515,14 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+query-string@^4.1.0:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -16069,6 +16136,11 @@ strip-outer@^1.0.0:
   integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
   dependencies:
     escape-string-regexp "^1.0.2"
+
+strip-url-auth@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
+  integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
 
 style-inject@^0.3.0:
   version "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1670,10 +1670,23 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
   integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/react@^16.8.16":
+  version "16.8.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.16.tgz#2bf980b4fb29cceeb01b2c139b3e185e57d3e08e"
+  integrity sha512-A0+6kS6zwPtvubOLiCJmZ8li5bm3wKIkoKV0h3RdMDOnCj9cYkUnj3bWbE03/lcICdQmwBmUfoFiHeNhbFiyHQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1708,6 +1721,35 @@
     "@types/node" "*"
     "@types/unist" "*"
     "@types/vfile-message" "*"
+
+"@typescript-eslint/eslint-plugin@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.7.0.tgz#570e45dc84fb97852e363f1e00f47e604a0b8bcc"
+  integrity sha512-NUSz1aTlIzzTjFFVFyzrbo8oFjHg3K/M9MzYByqbMCxeFdErhLAcGITVfXzSz+Yvp5OOpMu3HkIttB0NyKl54Q==
+  dependencies:
+    "@typescript-eslint/parser" "1.7.0"
+    "@typescript-eslint/typescript-estree" "1.7.0"
+    eslint-utils "^1.3.1"
+    regexpp "^2.0.1"
+    requireindex "^1.2.0"
+    tsutils "^3.7.0"
+
+"@typescript-eslint/parser@1.7.0", "@typescript-eslint/parser@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.7.0.tgz#c3ea0d158349ceefbb6da95b5b09924b75357851"
+  integrity sha512-1QFKxs2V940372srm12ovSE683afqc1jB6zF/f8iKhgLz1yoSjYeGHipasao33VXKI+0a/ob9okeogGdKGvvlg==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "1.7.0"
+    eslint-scope "^4.0.0"
+    eslint-visitor-keys "^1.0.0"
+
+"@typescript-eslint/typescript-estree@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.7.0.tgz#59ec02f5371964da1cc679dba7b878a417bc8c60"
+  integrity sha512-K5uedUxVmlYrVkFbyV3htDipvLqTE3QMOUQEHYJaKtgzxj6r7c5Ca/DG1tGgFxX+fsbi9nDIrf4arq7Ib7H/Yw==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -4778,6 +4820,11 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.4.tgz#d585a6062096e324e7187f80e04f92bd0f00e37f"
+  integrity sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg==
+
 csstype@^2.5.7:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
@@ -5773,11 +5820,6 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-email-addresses@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.0.3.tgz#fc3c6952f68da24239914e982c8a7783bc2ed96d"
-  integrity sha512-kUlSC06PVvvjlMRpNIl3kR1NRXLEe86VQ7N0bQeaCZb2g+InShCeHQp/JvyYNTugMnRN2NvJhHlc3q12MWbbpg==
-
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
@@ -5957,19 +5999,19 @@ eslint-config-prettier@^4.1.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-react-app@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-4.0.0.tgz#1651f44b3830d863817af6ebed0916193aa870c3"
-  integrity sha512-SeFxaI+0NAzWPFAI9AT+Vp9Xe2u5RCnn0JVEXkE338HgoPujc38Bc0upCJw4BWmavvIN/ODmE6EuzHoAEn3ozw==
-  dependencies:
-    confusing-browser-globals "^1.0.7"
-
 eslint-config-react-app@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.8.tgz#6f606828ba30bafee7d744c41cd07a3fea8f3035"
   integrity sha512-Ovi6Bva67OjXrom9Y/SLJRkrGqKhMAL0XCH8BizPhjEVEhYczl2ZKiNZI2CuqO5/CJwAfMwRXAVGY0KToWr1aA==
   dependencies:
     confusing-browser-globals "^1.0.6"
+
+eslint-config-react-app@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-4.0.0.tgz#1651f44b3830d863817af6ebed0916193aa870c3"
+  integrity sha512-SeFxaI+0NAzWPFAI9AT+Vp9Xe2u5RCnn0JVEXkE338HgoPujc38Bc0upCJw4BWmavvIN/ODmE6EuzHoAEn3ozw==
+  dependencies:
+    confusing-browser-globals "^1.0.7"
 
 eslint-import-resolver-node@^0.3.1, eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -5990,7 +6032,15 @@ eslint-loader@2.1.1:
     object-hash "^1.1.4"
     rimraf "^2.6.1"
 
-eslint-module-utils@^2.2.0, eslint-module-utils@^2.4.0:
+eslint-module-utils@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
+  integrity sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
+eslint-module-utils@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
   integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
@@ -6005,12 +6055,12 @@ eslint-plugin-flowtype@2.50.1:
   dependencies:
     lodash "^4.17.10"
 
-eslint-plugin-flowtype@2.x:
-  version "2.50.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.3.tgz#61379d6dce1d010370acd6681740fd913d68175f"
-  integrity sha512-X+AoKVOr7Re0ko/yEXyM5SSZ0tazc6ffdIOocp2fFUlWoDt7DV0Bz99mngOkAFLOAWjqRA5jPwqUCbrx13XoxQ==
+eslint-plugin-flowtype@^3.6.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.7.0.tgz#6662392f2daf6056138448b46ebc17c7a83ad337"
+  integrity sha512-6PAYrfSAd23C6ZTc9OhEpSn4uz5HnaXSOYzBLPiKNAE+WmNnWkgkfrswOK2Rlvn91ofZoba7SR04gitnmW9sqg==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 eslint-plugin-import@2.14.0:
   version "2.14.0"
@@ -6028,10 +6078,10 @@ eslint-plugin-import@2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-import@2.x:
-  version "2.17.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.3.tgz#00548b4434c18faebaba04b24ae6198f280de189"
-  integrity sha512-qeVf/UwXFJbeyLbxuY8RgqDyEKCkqV7YC+E5S5uOjAp4tOc8zj01JP3ucoBM8JcEqd1qRasJSg6LLlisirfy0Q==
+eslint-plugin-import@^2.17.2:
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
+  integrity sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==
   dependencies:
     array-includes "^3.0.3"
     contains-path "^0.1.0"
@@ -6043,7 +6093,7 @@ eslint-plugin-import@2.x:
     lodash "^4.17.11"
     minimatch "^3.0.4"
     read-pkg-up "^2.0.0"
-    resolve "^1.11.0"
+    resolve "^1.10.0"
 
 eslint-plugin-jsx-a11y@6.1.2:
   version "6.1.2"
@@ -6059,7 +6109,7 @@ eslint-plugin-jsx-a11y@6.1.2:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
-eslint-plugin-jsx-a11y@6.x:
+eslint-plugin-jsx-a11y@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz#4ebba9f339b600ff415ae4166e3e2e008831cf0c"
   integrity sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==
@@ -6098,7 +6148,7 @@ eslint-plugin-react@7.12.4:
     prop-types "^15.6.2"
     resolve "^1.9.0"
 
-eslint-plugin-react@7.x:
+eslint-plugin-react@^7.12.4:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
   integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
@@ -6180,7 +6230,7 @@ eslint@5.12.0:
     table "^5.0.2"
     text-table "^0.2.0"
 
-eslint@5.x:
+eslint@^5.16.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
   integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
@@ -6782,32 +6832,10 @@ filename-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
   integrity sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=
 
-filename-reserved-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz#e61cf805f0de1c984567d0386dc5df50ee5af7e4"
-  integrity sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=
-
 filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
   integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
-
-filenamify-url@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/filenamify-url/-/filenamify-url-1.0.0.tgz#b32bd81319ef5863b73078bed50f46a4f7975f50"
-  integrity sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=
-  dependencies:
-    filenamify "^1.0.0"
-    humanize-url "^1.0.0"
-
-filenamify@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-1.2.1.tgz#a9f2ffd11c503bed300015029272378f1f1365a5"
-  integrity sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=
-  dependencies:
-    filename-reserved-regex "^1.0.0"
-    strip-outer "^1.0.0"
-    trim-repeated "^1.0.0"
 
 filenamify@^2.0.0:
   version "2.1.0"
@@ -7337,20 +7365,6 @@ getport@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/getport/-/getport-0.1.0.tgz#abddf3d5d1e77dd967ccfa2b036a0a1fb26fd7f7"
   integrity sha1-q93z1dHnfdlnzPorA2oKH7Jv1/c=
-
-gh-pages@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-2.0.1.tgz#aefe47a43b8d9d2aa3130576b33fe95641e29a2f"
-  integrity sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==
-  dependencies:
-    async "^2.6.1"
-    commander "^2.18.0"
-    email-addresses "^3.0.1"
-    filenamify-url "^1.0.0"
-    fs-extra "^7.0.0"
-    globby "^6.1.0"
-    graceful-fs "^4.1.11"
-    rimraf "^2.6.2"
 
 gifsicle@^4.0.0:
   version "4.0.1"
@@ -8141,14 +8155,6 @@ humanize-string@^1.0.2:
   integrity sha512-PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==
   dependencies:
     decamelize "^1.0.0"
-
-humanize-url@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/humanize-url/-/humanize-url-1.0.1.tgz#f4ab99e0d288174ca4e1e50407c55fbae464efff"
-  integrity sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=
-  dependencies:
-    normalize-url "^1.0.0"
-    strip-url-auth "^1.0.0"
 
 husky@^1.3.1:
   version "1.3.1"
@@ -10377,6 +10383,11 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -11562,16 +11573,6 @@ normalize-url@2.0.1:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
-
-normalize-url@^1.0.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
-  integrity sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=
-  dependencies:
-    object-assign "^4.0.1"
-    prepend-http "^1.0.0"
-    query-string "^4.1.0"
-    sort-keys "^1.0.0"
 
 normalize-url@^3.0.0:
   version "3.3.0"
@@ -13200,7 +13201,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prepend-http@^1.0.0, prepend-http@^1.0.1:
+prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
@@ -13455,14 +13456,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-query-string@^4.1.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
-  integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -14654,6 +14647,11 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -14731,10 +14729,17 @@ resolve@1.10.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1, resolve@^1.9.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
-  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1, resolve@^1.9.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
   dependencies:
     path-parse "^1.0.6"
 
@@ -15196,6 +15201,11 @@ semver-truncate@^1.1.2:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
 semver@^6.1.1:
   version "6.1.1"
@@ -16060,11 +16070,6 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-strip-url-auth@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
-  integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
-
 style-inject@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
@@ -16704,10 +16709,17 @@ ts-pnp@^1.0.0:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1.9.0, tslib@^1.9.3:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tsutils@^3.7.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.10.0.tgz#6f1c95c94606e098592b0dff06590cf9659227d6"
+  integrity sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -16760,6 +16772,11 @@ typeface-oswald@0.0.54:
   version "0.0.54"
   resolved "https://registry.yarnpkg.com/typeface-oswald/-/typeface-oswald-0.0.54.tgz#1e253011622cdd50f580c04e7d625e7f449763d7"
   integrity sha512-U1WMNp4qfy4/3khIfHMVAIKnNu941MXUfs3+H9R8PFgnoz42Hh9pboSFztWr86zut0eXC8byalmVhfkiKON/8Q==
+
+typescript@^3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
This PR includes
- New array prop called `markers` to render the desired content on top of the map at lat and long.
- Fix custom gl layers, so now we are able to render any layer following the mapbox spec
- Typescript definition types for the exported components.
However, it still doesn't work for code splitting imports
![image](https://user-images.githubusercontent.com/10500650/57386414-91761e00-71b4-11e9-9214-9fab4deab71f.png)

So you have to include the following code on the project you want to use them:
```
declare module '@globalfishingwatch/map-components/components/countryflag' {
  import { CountryFlag } from '@globalfishingwatch/map-components'
  export = CountryFlag
}
```