### PR TITLE
Fix crashes

### DIFF
--- a/src/map/heatmap/heatmap.actions.js
+++ b/src/map/heatmap/heatmap.actions.js
@@ -481,6 +481,10 @@ export const updateHeatmapLayers = (newLayers, currentLoadTemporalExtent) => (
   dispatch,
   getState
 ) => {
+  if (newLayers === null) {
+    console.warn("New layers in updateHeatmapLayers can't be null")
+    return
+  }
   const prevLayersDict = getState().map.heatmap.heatmapLayers
 
   // add and update layers

--- a/src/map/map.js
+++ b/src/map/map.js
@@ -119,7 +119,9 @@ class MapModule extends React.Component {
     })
 
     // heatmap layers
-    store.dispatch(updateHeatmapLayers(this.props.heatmapLayers, this.props.loadTemporalExtent))
+    if (this.props.heatmapLayers !== null) {
+      store.dispatch(updateHeatmapLayers(this.props.heatmapLayers, this.props.loadTemporalExtent))
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/src/timebar/components/timeline.js
+++ b/src/timebar/components/timeline.js
@@ -32,12 +32,13 @@ class Timeline extends Component {
       outerHeight: 50,
       dragging: null,
     }
+    this.graphContainer = null
     this.isMovingInside = false
   }
 
   componentDidMount() {
     // wait for end of call stack to get rendered CSS
-    window.setTimeout(this.onWindowResize, 1)
+    window.setTimeout(this.onWindowResize, 10)
     window.addEventListener('resize', this.onWindowResize)
     window.addEventListener('mousemove', this.onMouseMove)
     window.addEventListener('touchmove', this.onMouseMove)
@@ -56,21 +57,23 @@ class Timeline extends Component {
   }
 
   onWindowResize = () => {
-    const graphStyle = window.getComputedStyle(this.graphContainer)
-    const outerX = parseFloat(this.graphContainer.getBoundingClientRect().left)
-    const outerWidth = parseFloat(graphStyle.width)
-    const outerHeight = parseFloat(graphStyle.height)
-    const innerStartPx = outerWidth * 0.15
-    const innerEndPx = outerWidth * 0.85
-    const innerWidth = outerWidth * 0.7
-    this.setState({
-      outerX,
-      innerStartPx,
-      innerEndPx,
-      innerWidth,
-      outerWidth,
-      outerHeight,
-    })
+    if (this.graphContainer !== null) {
+      const graphStyle = window.getComputedStyle(this.graphContainer)
+      const outerX = parseFloat(this.graphContainer.getBoundingClientRect().left)
+      const outerWidth = parseFloat(graphStyle.width)
+      const outerHeight = parseFloat(graphStyle.height)
+      const innerStartPx = outerWidth * 0.15
+      const innerEndPx = outerWidth * 0.85
+      const innerWidth = outerWidth * 0.7
+      this.setState({
+        outerX,
+        innerStartPx,
+        innerEndPx,
+        innerWidth,
+        outerWidth,
+        outerHeight,
+      })
+    }
   }
 
   isHandlerZoomInValid(x) {
@@ -391,6 +394,7 @@ Timeline.propTypes = {
   end: PropTypes.string.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
+  onBookmarkChange: PropTypes.func,
   bookmarkStart: PropTypes.string,
   bookmarkEnd: PropTypes.string,
 }
@@ -398,6 +402,7 @@ Timeline.propTypes = {
 Timeline.defaultProps = {
   bookmarkStart: null,
   bookmarkEnd: null,
+  onBookmarkChange: () => {},
   onMouseLeave: () => {},
   onMouseMove: () => {},
 }


### PR DESCRIPTION
Data portal was broken with latest changes because:
- It doesn't use heatmapLayers => onDidMount only trigger the update when has layers
- Timebar ref wasn't ready => check when the ref is still null on resize event