### PR TITLE
Timebar date mouse press

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "gh-pages": "^2.0.1",
     "husky": "^1.3.1",
     "imagemin-lint-staged": "^0.4.0",

--- a/sandbox/public/index.html
+++ b/sandbox/public/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the

--- a/sandbox/src/index.css
+++ b/sandbox/src/index.css
@@ -1,3 +1,7 @@
+html {
+  font-size: 10px;
+}
+
 body {
   margin: 0;
   padding: 0;

--- a/src/timebar/components/date-selector.js
+++ b/src/timebar/components/date-selector.js
@@ -5,6 +5,43 @@ import { ReactComponent as IconArrowUp } from '../icons/arrowUp.svg'
 import { ReactComponent as IconArrowDown } from '../icons/arrowDown.svg'
 
 class DateSelector extends Component {
+  pressing = 0
+  pressingInterval = null
+  pressingTimeout = null
+
+  onMouseDown(increment) {
+    this.clear()
+    const { onChange } = this.props
+    this.pressing = increment
+    onChange(this.pressing)
+    this.pressingTimeout = window.setTimeout(this.startTimeout, 800)
+    window.addEventListener('mouseup', this.onMouseUp)
+  }
+
+  startTimeout = () => {
+    this.pressingInterval = window.setInterval(this.onInterval, 80)
+  }
+
+  onInterval = () => {
+    const { onChange } = this.props
+    onChange(this.pressing)
+  }
+
+  onMouseUp = () => {
+    this.clear()
+    this.pressing = 0
+  }
+
+  clear() {
+    window.clearInterval(this.pressingInterval)
+    window.clearTimeout(this.pressingTimeout)
+    window.removeEventListener('mouseup', this.onMouseUp)
+  }
+
+  componentWillUnmount() {
+    this.clear()
+  }
+
   render() {
     const { onChange, value, canIncrement, canDecrement } = this.props
     return (
@@ -13,8 +50,8 @@ class DateSelector extends Component {
           type="button"
           className={styles.arrowButton}
           disabled={!canIncrement}
-          onClick={() => {
-            onChange(+1)
+          onMouseDown={() => {
+            this.onMouseDown(+1)
           }}
         >
           <IconArrowUp />
@@ -24,8 +61,8 @@ class DateSelector extends Component {
           type="button"
           className={styles.arrowButton}
           disabled={!canDecrement}
-          onClick={() => {
-            onChange(-1)
+          onMouseDown={() => {
+            this.onMouseDown(-1)
           }}
         >
           <IconArrowDown />

--- a/src/timebar/components/timerange-selector.js
+++ b/src/timebar/components/timerange-selector.js
@@ -96,80 +96,82 @@ class TimeRangeSelector extends Component {
     return (
       <div className={styles.TimeRangeSelector}>
         <div className={styles.veil} onClick={this.props.onDiscard} />
-        <h2>Select a time range</h2>
-        <div className={styles.selectorsContainer}>
-          <div className={styles.selectorGroup}>
-            <span className={styles.selectorLabel}>START</span>
-            <DateSelector
-              canIncrement={startCanIncrement}
-              canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'day', offset)
-              }}
-              value={mStart.date()}
-            />
-            <DateSelector
-              canIncrement={startCanIncrement}
-              canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'month', offset)
-              }}
-              value={mStart.format('MMM')}
-            />
-            <DateSelector
-              canIncrement={startCanIncrement}
-              canDecrement={startCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('start', bounds, 'year', offset)
-              }}
-              value={mStart.year()}
-            />
+        <div className={styles.inner}>
+          <h2>Select a time range</h2>
+          <div className={styles.selectorsContainer}>
+            <div className={styles.selectorGroup}>
+              <span className={styles.selectorLabel}>START</span>
+              <DateSelector
+                canIncrement={startCanIncrement}
+                canDecrement={startCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('start', bounds, 'day', offset)
+                }}
+                value={mStart.date()}
+              />
+              <DateSelector
+                canIncrement={startCanIncrement}
+                canDecrement={startCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('start', bounds, 'month', offset)
+                }}
+                value={mStart.format('MMM')}
+              />
+              <DateSelector
+                canIncrement={startCanIncrement}
+                canDecrement={startCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('start', bounds, 'year', offset)
+                }}
+                value={mStart.year()}
+              />
+            </div>
+            <div className={styles.selectorGroup}>
+              <span className={styles.selectorLabel}>END</span>
+              <DateSelector
+                canIncrement={endCanIncrement}
+                canDecrement={endCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('end', bounds, 'day', offset)
+                }}
+                value={mEnd.date()}
+              />
+              <DateSelector
+                canIncrement={endCanIncrement}
+                canDecrement={endCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('end', bounds, 'month', offset)
+                }}
+                value={mEnd.format('MMM')}
+              />
+              <DateSelector
+                canIncrement={endCanIncrement}
+                canDecrement={endCanDecrement}
+                onChange={(offset) => {
+                  this.setUnit('end', bounds, 'year', offset)
+                }}
+                value={mEnd.year()}
+              />
+            </div>
           </div>
-          <div className={styles.selectorGroup}>
-            <span className={styles.selectorLabel}>END</span>
-            <DateSelector
-              canIncrement={endCanIncrement}
-              canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'day', offset)
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={classNames(styles.cta, styles.secondary)}
+              onClick={this.last30days}
+            >
+              LAST 30 DAYS
+            </button>
+            <button
+              type="button"
+              className={styles.cta}
+              onClick={() => {
+                this.submit(start, end)
               }}
-              value={mEnd.date()}
-            />
-            <DateSelector
-              canIncrement={endCanIncrement}
-              canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'month', offset)
-              }}
-              value={mEnd.format('MMM')}
-            />
-            <DateSelector
-              canIncrement={endCanIncrement}
-              canDecrement={endCanDecrement}
-              onChange={(offset) => {
-                this.setUnit('end', bounds, 'year', offset)
-              }}
-              value={mEnd.year()}
-            />
+            >
+              DONE
+            </button>
           </div>
-        </div>
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={classNames(styles.cta, styles.secondary)}
-            onClick={this.last30days}
-          >
-            LAST 30 DAYS
-          </button>
-          <button
-            type="button"
-            className={styles.cta}
-            onClick={() => {
-              this.submit(start, end)
-            }}
-          >
-            DONE
-          </button>
         </div>
       </div>
     )
@@ -182,6 +184,7 @@ TimeRangeSelector.propTypes = {
   end: PropTypes.string.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,
+  onDiscard: PropTypes.func.isRequired,
 }
 
 export default TimeRangeSelector

--- a/src/timebar/components/timerange-selector.module.css
+++ b/src/timebar/components/timerange-selector.module.css
@@ -5,7 +5,6 @@
   width: 46rem;
   background: var(--timebar-main-background-color);
   border: 1px solid rgba(255, 255, 255, 0.3);
-  padding: 3.5rem 3rem 3rem;
   box-sizing: border-box;
   z-index: 0;
   box-shadow: 0 0 28px 5px rgba(0, 0, 0, 0.8);
@@ -21,6 +20,10 @@
   background: var(--timebar-main-background-color);
   opacity: 0.7;
   z-index: -1;
+}
+
+.inner {
+  padding: 3.5rem 3rem 3rem;
 }
 
 h2 {

--- a/src/timebar/timebar.js
+++ b/src/timebar/timebar.js
@@ -31,6 +31,7 @@ class Timebar extends Component {
     super()
     this.state = {
       showTimeRangeSelector: false,
+      absoluteEnd: null,
     }
   }
 
@@ -59,7 +60,7 @@ class Timebar extends Component {
 
   setBookmark = () => {
     const { start, end, onBookmarkChange } = this.props
-    onBookmarkChange(start, end)
+    onBookmarkChange !== null && onBookmarkChange(start, end)
   }
 
   onTimeRangeSelectorSubmit = (start, end) => {
@@ -258,6 +259,11 @@ class Timebar extends Component {
 }
 
 Timebar.propTypes = {
+  start: PropTypes.string.isRequired,
+  end: PropTypes.string.isRequired,
+  bookmarkStart: PropTypes.string,
+  bookmarkEnd: PropTypes.string,
+  onBookmarkChange: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   absoluteStart: PropTypes.string.isRequired,
   absoluteEnd: PropTypes.string.isRequired,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6506,6 +6506,11 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@7.12.4, eslint-plugin-react@7.x:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
Allows changing timebar start and end by "long-pressing" up and down arrows on date selectors.

Also brings some of the changes made in https://github.com/GlobalFishingWatch/map-components/pull/48 as well as a fix to close date selector when clicking on veil.
 