### PR TITLE
Map z order

### DIFF
--- a/src/map/config.js
+++ b/src/map/config.js
@@ -46,6 +46,6 @@ export const STATIC_LAYERS_CARTO_ENDPOINT =
 export const STATIC_LAYERS_CARTO_TILES_ENDPOINT =
   'https://carto.globalfishingwatch.org/user/admin/api/v1/map/$LAYERGROUPID/{z}/{x}/{y}.mvt'
 
-export const TRACKS_LAYER_IN_FRONT_OF_GROUP = 'static'
+export const TRACKS_LAYER_IN_FRONT_OF_GROUP = 'temporal'
 
 export const TILES_URL_NEEDING_AUTHENTICATION = 'dot-world-fishing'

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -43,8 +43,6 @@ const getMapStyle = createSelector(
       mapStylesLayers = mapStylesLayers.insert(trackLayersIndex + i, fromJS(trackLayer))
     })
     finalMapStyles = finalMapStyles.set('layers', mapStylesLayers)
-    console.log('map style generated after including tracks')
-    console.log(finalMapStyles.toJS())
     return finalMapStyles
   }
 )

--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -43,7 +43,8 @@ const getMapStyle = createSelector(
       mapStylesLayers = mapStylesLayers.insert(trackLayersIndex + i, fromJS(trackLayer))
     })
     finalMapStyles = finalMapStyles.set('layers', mapStylesLayers)
-
+    console.log('map style generated after including tracks')
+    console.log(finalMapStyles.toJS())
     return finalMapStyles
   }
 )

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -165,6 +165,7 @@ class Map extends React.Component {
           minZoom={minZoom}
           onViewportChange={this.onViewportChange}
           interactiveLayerIds={interactiveLayerIds}
+          clickRadius={4}
         >
           {hasHeatmapLayers !== false && <ActivityLayers />}
           {clickPopup !== undefined && clickPopup !== null && (

--- a/src/map/glmap/style.actions.js
+++ b/src/map/glmap/style.actions.js
@@ -304,7 +304,6 @@ const addWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
     const finalSource = fromJS(gl.source)
     style = style.setIn(['sources', id], finalSource)
 
-    const layers = []
     gl.layers.forEach((workspaceGlLayer) => {
       const sourceLayer =
         workspaceGlLayer['source-layer'] === undefined ? id : workspaceGlLayer['source-layer']
@@ -320,12 +319,13 @@ const addWorkspaceGLLayers = (workspaceGLLayers) => (dispatch, getState) => {
         source: id,
         'source-layer': sourceLayer,
       }
-
-      layers.push(glLayer)
+      const existingLayers = style.get('layers')
+      const newLayerGroup = glLayer.metadata['mapbox:group']
+      const newLayerIndex = existingLayers.findLastIndex((l) => {
+        return newLayerGroup === l.toJS().metadata['mapbox:group']
+      })
+      style = style.set('layers', existingLayers.splice(newLayerIndex, 0, fromJS(glLayer)))
     })
-
-    const finalLayers = fromJS(layers)
-    style = style.set('layers', style.get('layers').concat(finalLayers))
   })
 
   dispatch(setMapStyle(style))

--- a/src/map/glmap/style.reducer.js
+++ b/src/map/glmap/style.reducer.js
@@ -22,14 +22,22 @@ export const setLayerStyleDefaults = (layer) => {
   if (layer.paint === undefined) {
     layer.paint = {}
   }
+  if (layer.metadata === undefined) {
+    layer.metadata = {}
+  }
   // initialize time filter for time-filterable layers
-  if (layer.metadata && layer.metadata['gfw:temporal'] === true) {
+  if (layer.metadata['gfw:temporal'] === true) {
     const temporalField =
       layer.metadata['gfw:temporalField'] === undefined
         ? 'timestamp'
         : layer.metadata['gfw:temporalField']
     layer.filter = ['all', ['>', temporalField, 0], ['<', temporalField, 999999999999]]
   }
+
+  if (layer.metadata['mapbox:group'] === undefined) {
+    layer.metadata['mapbox:group'] = 'temporal'
+  }
+
   // set all layers to not visible except layers explicitely marked as visible (default basemap)
   if (layer.layout.visibility !== 'visible') {
     layer.layout.visibility = 'none'


### PR DESCRIPTION
This fixes issues with z-ordering of map layers:

- track now always appear on top of temporal layers

![Screenshot 2019-06-28 at 11 53 11](https://user-images.githubusercontent.com/1583415/60337233-c3308780-99a2-11e9-91d3-f463ca1415e8.png)

- when using custom layers with a `gl` parameter, the `mapbox:group` will now be used correctly for z-ordering, instead of always having the layer on top of everything. This allows basemap labels to show up correctly:

![Screenshot 2019-06-28 at 12 42 29](https://user-images.githubusercontent.com/1583415/60337283-eeb37200-99a2-11e9-9d4f-61494a2d7e28.png)
![Screenshot 2019-06-28 at 12 45 32](https://user-images.githubusercontent.com/1583415/60337284-ef4c0880-99a2-11e9-94a7-2f32c1628042.png)
 