### PR TITLE
Fix the bug where map wasn't resizing when parent did

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-spring": "^8.0.19",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "topojson-client": "^3.0.0",
     "viewport-mercator-project": "^6.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "d3-scale": "^2.2.2",
     "d3-shape": "^1.3.4",
     "immutable": "^4.0.0-rc.12",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.13",
     "mapbox-gl": "^0.53.1",
     "memoize-one": "^5.0.0",
     "pbf": "^3.2.0",

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -2678,6 +2678,11 @@ core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
+core-js@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.4.tgz#3a2837fc48e582e1ae25907afcd6cf03b0cc7a07"
+  integrity sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2708,11 +2713,12 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.0.5, cosmiconfig@^5.0.6:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-countryflag@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/countryflag/-/countryflag-2.3.1.tgz#e2fe3efdd919284dbad9d9361b107791f28231cc"
-  integrity sha512-K1UrSI0baB/lxFt+WgB73eIdWFXVmD902uAOCK/n03ezgoe9RSgHBpGyEEdYMXw9r/YB0rQqPmSKck3/YtLDSA==
+countryflag@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/countryflag/-/countryflag-2.4.0.tgz#a3a299603838f36fb028f9ae6e37d8373a2c195f"
+  integrity sha512-NuAAvNnc/OinEvO3pbFZ7nnrjAEu0suzsMcPKczm8QZZBot6/IiKDZNaOx1clfU4QlqlDGgBpDxDMcvAcYn8YA==
   dependencies:
+    core-js "^3.1.4"
     if-emoji "^0.1.0"
     world-countries "^2.1.0"
 
@@ -8770,6 +8776,11 @@ reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"

--- a/sandbox/yarn.lock
+++ b/sandbox/yarn.lock
@@ -6236,10 +6236,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.11:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
 loglevel@^1.4.1:
   version "1.6.2"

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -43,7 +43,13 @@ class Map extends React.Component {
       mouseOver: true,
     }
     this._mapContainerRef = null
+    this._containerResizeObserver = new ResizeObserver(this._containerResize)
   }
+
+  _containerResize = () => {
+    window.setTimeout(() => this._resize(), 1)
+  }
+
   componentDidMount() {
     window.addEventListener('resize', this._resize)
     this._resize()
@@ -58,6 +64,7 @@ class Map extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this._resize)
+    this._containerResizeObserver.unobserve(this._mapContainerRef)
   }
 
   _resize = () => {
@@ -144,6 +151,9 @@ class Map extends React.Component {
         className={styles.map}
         ref={(ref) => {
           this._mapContainerRef = ref
+          if (this._mapContainerRef !== null) {
+            this._containerResizeObserver.observe(this._mapContainerRef)
+          }
         }}
         onMouseLeave={() => {
           this.setState({ mouseOver: false })

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -46,35 +46,10 @@ class Map extends React.Component {
     this._containerResizeObserver = new ResizeObserver(this._containerResize)
   }
 
-  _containerResize = () => {
-    window.setTimeout(() => this._resize(), 1)
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this._resize)
-    this._resize()
-
-    // useful with FOUC
-    window.setTimeout(() => this._resize(), 1)
-
-    // there is a problem with the container width computation (only with "fat scrollbar" browser/os configs),
-    // seems like the panels with scrollbars are taken into account or smth
-    window.setTimeout(() => this._resize(), 10000)
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this._resize)
-    this._containerResizeObserver.unobserve(this._mapContainerRef)
-  }
-
-  _resize = () => {
-    if (this._mapContainerRef === null) {
-      console.warn('Cant set viewport on a map that hasnt finished intanciating yet')
-      return
-    }
-    const mapContainerStyle = window.getComputedStyle(this._mapContainerRef)
-    const width = parseInt(mapContainerStyle.width, 10)
-    const height = parseInt(mapContainerStyle.height, 10) + 1
+  _containerResize = (entries) => {
+    const mapContainerStyle = entries[0].contentRect
+    const width = mapContainerStyle.width
+    const height = mapContainerStyle.height + 1
 
     if (width !== this.props.viewport.width || height !== this.props.viewport.height) {
       this.props.setViewport({
@@ -83,6 +58,10 @@ class Map extends React.Component {
         height,
       })
     }
+  }
+
+  componentWillUnmount() {
+    this._containerResizeObserver.disconnect()
   }
 
   onViewportChange = (viewport) => {

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -65,8 +65,8 @@ class Map extends React.Component {
     this._containerResizeObserver.disconnect()
   }
 
-  onViewportChange = (viewport) => {
-    this.props.setViewport(viewport)
+  onViewportChange = (viewport, interactionState) => {
+    this.props.setViewport(viewport, interactionState)
   }
 
   onMapInteraction = (event, type) => {

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -48,13 +48,12 @@ class Map extends React.Component {
   }
 
   _containerResize = (entries) => {
-    const mapContainerStyle = entries[0].contentRect
-    const width = mapContainerStyle.width
-    const height = mapContainerStyle.height + 1
+    const { width, height } = entries[0].contentRect
+    const { viewport, setViewport } = this.props
 
-    if (width !== this.props.viewport.width || height !== this.props.viewport.height) {
-      this.props.setViewport({
-        ...this.props.viewport,
+    if (width !== viewport.width || height !== viewport.height) {
+      setViewport({
+        ...viewport,
         width,
         height,
       })

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -5,6 +5,7 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import { TILES_URL_NEEDING_AUTHENTICATION } from '../config'
 import ActivityLayers from '../activity/ActivityLayers.container.js'
 import styles from './map.css'
+import ResizeObserver from 'resize-observer-polyfill'
 
 const PopupWrapper = (props) => {
   const { latitude, longitude, children, closeButton, onClose } = props

--- a/yarn.lock
+++ b/yarn.lock
@@ -14669,6 +14669,11 @@ reserved-words@^0.1.2:
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10447,6 +10447,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.13:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
Uses ResizeObserver to fix the bug where map wasn't resizing when parent did.

Before merging, we need to add a polyfill for ResizeObserver or even implement the same behaviour with `react-resize-detector` or similar.
