### PR TITLE
[WIP] Fixes double basemap rendering

### DIFF
--- a/src/map/glmap/gl-styles/style.json
+++ b/src/map/glmap/gl-styles/style.json
@@ -273,10 +273,7 @@
         "mapbox:group": "basemap-background"
       },
       "type": "raster",
-      "source": "satellite",
-      "layout": {
-        "visibility": "visible"
-      }
+      "source": "satellite"
     },
     {
       "id": "north-star",


### PR DESCRIPTION
It fixes it only by removing the default visibility of the satellite basemap.
It works on carrier-portal, but we need to check if other products are passing a basemap prop.