### PR TITLE
save map bounds when no activity layer

### DIFF
--- a/src/map/glmap/Map.container.js
+++ b/src/map/glmap/Map.container.js
@@ -5,7 +5,7 @@ import { TRACKS_LAYER_IN_FRONT_OF_GROUP } from '../config'
 import { closePopup } from '../module/module.actions.js'
 import { getTracksStyles } from '../tracks/tracks.selectors.js'
 import { mapInteraction } from './interaction.actions.js'
-import { setViewport, transitionEnd } from './viewport.actions.js'
+import { setBounds, setViewport, transitionEnd } from './viewport.actions.js'
 import Map from './Map'
 
 const getStaticLayers = (state) => state.map.style.staticLayers
@@ -92,6 +92,9 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch) => ({
   setViewport: (viewport, interactionState) => {
     dispatch(setViewport(viewport, interactionState))
+  },
+  setBounds: (bounds) => {
+    dispatch(setBounds(bounds))
   },
   mapInteraction: (type, lat, long, features, cluster, glGetSource) => {
     dispatch(mapInteraction(type, lat, long, features, cluster, glGetSource))

--- a/src/map/glmap/Map.js
+++ b/src/map/glmap/Map.js
@@ -49,6 +49,15 @@ class Map extends React.Component {
     if (this._mapContainerRef !== null) {
       this.loadObserver()
     }
+    if (this.glMap && this.props.setBounds !== undefined) {
+      const { _ne, _sw } = this.glMap.getBounds()
+      this.props.setBounds({
+        north: _ne.lat,
+        south: _sw.lat,
+        west: _sw.lng,
+        east: _ne.lng,
+      })
+    }
   }
 
   componentWillUnmount() {
@@ -222,6 +231,7 @@ Map.propTypes = {
   maxZoom: PropTypes.number.isRequired,
   minZoom: PropTypes.number.isRequired,
   setViewport: PropTypes.func.isRequired,
+  setBounds: PropTypes.func,
   mapInteraction: PropTypes.func,
   onClosePopup: PropTypes.func,
   transitionEnd: PropTypes.func,
@@ -247,6 +257,7 @@ Map.defaultProps = {
   cursor: null,
   markers: null,
   interactiveLayerIds: null,
+  setBounds: undefined,
 }
 
 export default Map

--- a/src/map/glmap/viewport.actions.js
+++ b/src/map/glmap/viewport.actions.js
@@ -3,12 +3,18 @@ import { updateHeatmapTilesFromViewport } from '../heatmap/heatmapTiles.actions'
 import { onViewportChange } from '../module/module.actions'
 import { CLUSTER_CLICK_ZOOM_INCREMENT } from '../config' // TODO MAP MODULE
 
+export const SET_BOUNDS = 'SET_BOUNDS'
 export const SET_VIEWPORT = 'SET_VIEWPORT'
 export const UPDATE_VIEWPORT = 'UPDATE_VIEWPORT'
 export const SET_ZOOM_INCREMENT = 'SET_ZOOM_INCREMENT'
 export const SET_MOUSE_LAT_LONG = 'SET_MOUSE_LAT_LONG'
 export const TRANSITION_END = 'TRANSITION_END'
 export const SET_NATIVE_VIEWPORT = 'SET_NATIVE_VIEWPORT'
+
+export const setBounds = (bounds) => ({
+  type: SET_BOUNDS,
+  payload: bounds,
+})
 
 export const setViewport = (viewport, interactionState) => (dispatch) => {
   dispatch({

--- a/src/map/glmap/viewport.reducer.js
+++ b/src/map/glmap/viewport.reducer.js
@@ -3,6 +3,7 @@ import { easeCubic } from 'd3-ease'
 import { MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL } from '../config'
 import { TRANSITION_TYPE } from '../constants'
 import {
+  SET_BOUNDS,
   SET_VIEWPORT,
   UPDATE_VIEWPORT,
   SET_ZOOM_INCREMENT,
@@ -28,6 +29,7 @@ const initialState = {
     pitch: 0,
     width: 1000,
     height: 800,
+    bounds: {},
   },
   maxZoom: MAX_ZOOM_LEVEL,
   minZoom: MIN_ZOOM_LEVEL,
@@ -44,6 +46,13 @@ export default function(state = initialState, action) {
         canZoomIn: action.payload.zoom < state.maxZoom,
         canZoomOut: action.payload.zoom > state.minZoom,
         prevZoom: state.viewport.zoom,
+      }
+    }
+
+    case SET_BOUNDS: {
+      return {
+        ...state,
+        bounds: action.payload,
       }
     }
 


### PR DESCRIPTION
Bounds is not available anymore in the viewport reducer when activity layers are disabled.

As we need the bounds in data-portal without any activity layer this PR will save them in the reducer on mapDidMount