### PR TITLE
add gl style generator

### DIFF
--- a/src/layer-manager/lib/generators/background/background.js
+++ b/src/layer-manager/lib/generators/background/background.js
@@ -1,6 +1,6 @@
 export const BACKGROUND_TYPE = 'BACKGROUND'
 
-class BasemapGenerator {
+class BackgroundGenerator {
   type = BACKGROUND_TYPE
 
   _getStyleLayers = (layer) => [
@@ -25,4 +25,4 @@ class BasemapGenerator {
   }
 }
 
-export default BasemapGenerator
+export default BackgroundGenerator

--- a/src/layer-manager/lib/generators/gl/gl.js
+++ b/src/layer-manager/lib/generators/gl/gl.js
@@ -1,0 +1,20 @@
+export const GL_TYPE = 'GL_TYLES'
+
+class GlStyleGenerator {
+  type = GL_TYPE
+
+  getStyle = (layer) => {
+    return {
+      id: layer.id,
+      // Auto generates sources and glLayers id using layer id when neccesary
+      sources: layer.sources.map((glSource) => ({ id: `${layer.id}`, ...glSource })),
+      layers: layer.layers.map((glLayer, i) => ({
+        id: `${layer.id}-${i}`,
+        source: layer.id,
+        ...glLayer,
+      })),
+    }
+  }
+}
+
+export default GlStyleGenerator

--- a/src/layer-manager/lib/generators/index.js
+++ b/src/layer-manager/lib/generators/index.js
@@ -1,15 +1,17 @@
 import BackgroundGenerator, { BACKGROUND_TYPE as BACKGROUND } from './background/background'
 import BaseMapGenerator, { BASEMAP_TYPE as BASEMAP } from './basemap/basemap'
+import GLStyleGenerator, { GL_TYPE as GL } from './gl/gl'
 import CartoGenerator, {
   CARTO_POLYGONS_TYPE as CARTO_POLYGONS,
   CARTO_FISHING_MAP_API,
 } from './carto-polygons/carto-polygons'
 
-const TYPES = { BASEMAP, CARTO_POLYGONS, BACKGROUND }
+const TYPES = { BASEMAP, CARTO_POLYGONS, BACKGROUND, GL }
 export { TYPES }
 
 export default {
   [BACKGROUND]: new BackgroundGenerator(),
   [BASEMAP]: new BaseMapGenerator(),
+  [GL]: new GLStyleGenerator(),
   [CARTO_POLYGONS]: new CartoGenerator({ baseUrl: CARTO_FISHING_MAP_API }),
 }


### PR DESCRIPTION
Allow to pass gl layers directly, for example:
```js
{
      id: 'cp_event_markers',
      type: TYPES.GL,
      sources: [
        {
          type: 'geojson',
          data: trackEvents || {},
        },
      ],
      layers: [
        {
          type: 'circle',
          layout: {
            visibility: trackEvents && vesselSelected ? 'visible' : 'none',
          },
          paint: {
            'circle-color': ['get', 'color'],
            'circle-stroke-width': 2,
            'circle-stroke-color': 'rgba(0, 193, 231, 1)',
            'circle-radius': ['case', ['==', ['get', 'active'], true], 12, 4],
          },
        },
      ],
    }
```