### PR TITLE
Added transformations to mapStyler hook

### DIFF
--- a/src/map-styler-hook/useMapStyler.js
+++ b/src/map-styler-hook/useMapStyler.js
@@ -1,19 +1,27 @@
 import { useEffect, useState } from 'react'
 
-function useMapStyler(layerComposer, layers) {
+const applyStyleTransformations = (style, styleTransformations) => {
+  let newStyle = style
+  styleTransformations.forEach((t) => {
+    newStyle = t(newStyle)
+  })
+  return newStyle
+}
+
+function useMapStyler(layerComposer, styleTransformations, layers) {
   const [mapStyle, setMapStyle] = useState(null)
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     const getGlStyles = async () => {
       const { style, promises } = layerComposer.getGLStyle(layers)
-      setMapStyle(style)
+      setMapStyle(applyStyleTransformations(style, styleTransformations))
       if (promises && promises.length) {
         setLoading(true)
         await Promise.all(
           promises.map((p) => {
             return p.then(({ style }) => {
-              setMapStyle(style)
+              setMapStyle(applyStyleTransformations(style, styleTransformations))
             })
           })
         )
@@ -21,7 +29,7 @@ function useMapStyler(layerComposer, layers) {
       }
     }
     getGlStyles()
-  }, [layerComposer, layers])
+  }, [layerComposer, styleTransformations, layers])
 
   return [mapStyle, loading]
 }


### PR DESCRIPTION
Simple mechanism to provide multiple transformations to style generated by LayerComposer. 

See example of usage:
https://github.com/GlobalFishingWatch/fourwings-demo/commit/568332017bf4ca785c8d4d793d77950ad839bc6e